### PR TITLE
Add non-mobile web support

### DIFF
--- a/src/components/input/math-input.js
+++ b/src/components/input/math-input.js
@@ -180,14 +180,16 @@ const MathInput = React.createClass({
           const y = evt.clientY;
           const containerBounds = this._container.getBoundingClientRect();
           if (this.state.focused && !rectContainsXY(containerBounds, x, y)) {
-              const isOutside = true;
+              let isOutside = true;
               if (this.props.keypadElement) {
                   const bounds = this._getKeypadBounds();
                   if (rectContainsXY(bounds, x, y) || bounds.bottom < y) {
                       isOutside = false;
                   }
               }
-              this.blur();
+              if (isOutside) {
+                this.blur();
+              }
           }
           this.didTouchOutside = false;
           this.didScroll = false;

--- a/src/components/input/math-input.js
+++ b/src/components/input/math-input.js
@@ -206,6 +206,8 @@ const MathInput = React.createClass({
         window.removeEventListener('resize', this._clearKeypadBoundsCache);
         window.removeEventListener(
                 'orientationchange', this._clearKeypadBoundsCache);
+        window.removeEventListener('keydown', this._forwardGlobalKeydown);
+        window.removeEventListener('keypress', this._forwardGlobalKeypress);
     },
 
     _clearKeypadBoundsCache(keypadNode) {

--- a/src/components/input/math-input.js
+++ b/src/components/input/math-input.js
@@ -288,7 +288,10 @@ const MathInput = React.createClass({
         e2.fakeForMathquill = true;
         this.mathField.fakeTextarea.value = String.fromCharCode(e.charCode);
         this.mathField.fakeTextarea.dispatchEvent(e2);
-        this._postKeyEvent();
+        // Mathquill seems to not be fully initialized for the first time this is called;
+        // this prevents the first keypress from being "lost"
+        // TODO(Aria): understand why.
+        setTimeout(this._postKeyEvent, 0);
     },
 
     blur() {

--- a/src/components/input/math-input.js
+++ b/src/components/input/math-input.js
@@ -228,6 +228,7 @@ const MathInput = React.createClass({
                 'orientationchange', this._clearKeypadBoundsCache);
         window.removeEventListener('keydown', this._forwardGlobalKeydown);
         window.removeEventListener('keypress', this._forwardGlobalKeypress);
+        window.removeEventListener('click', this.blurOnClickOutside);
     },
 
     _clearKeypadBoundsCache(keypadNode) {

--- a/src/components/input/math-input.js
+++ b/src/components/input/math-input.js
@@ -172,9 +172,29 @@ const MathInput = React.createClass({
             }
         };
 
+        this.blurOnClickOutside = (evt) => {
+          if (this.state.focused) {
+              const isOutside = true;
+              if (this.props.keypadElement) {
+                  const bounds = this._getKeypadBounds();
+                  const x = evt.clientX;
+                  const y = evt.clientY;
+                  if ((bounds.left <= x && bounds.right >= x &&
+                          bounds.top <= y && bounds.bottom >= y) ||
+                          bounds.bottom < y) {
+                      isOutside = false;
+                  }
+              }
+              this.blur();
+          }
+          this.didTouchOutside = false;
+          this.didScroll = false;
+        };
+
         window.addEventListener('touchstart', this.recordTouchStartOutside);
         window.addEventListener('touchend', this.blurOnTouchEndOutside);
         window.addEventListener('touchcancel', this.blurOnTouchEndOutside);
+        window.addEventListener('click', this.blurOnClickOutside);
 
         // HACK(benkomalo): if the window resizes, the keypad bounds can
         // change. That's a bit peeking into the internals of the keypad

--- a/src/components/input/math-input.js
+++ b/src/components/input/math-input.js
@@ -203,9 +203,9 @@ const MathInput = React.createClass({
         window.removeEventListener('touchstart', this.recordTouchStartOutside);
         window.removeEventListener('touchend', this.blurOnTouchEndOutside);
         window.removeEventListener('touchcancel', this.blurOnTouchEndOutside);
-        window.removeEventListener('resize', this._clearKeypadBoundsCache());
+        window.removeEventListener('resize', this._clearKeypadBoundsCache);
         window.removeEventListener(
-                'orientationchange', this._clearKeypadBoundsCache());
+                'orientationchange', this._clearKeypadBoundsCache);
     },
 
     _clearKeypadBoundsCache(keypadNode) {

--- a/src/components/input/math-wrapper.js
+++ b/src/components/input/math-wrapper.js
@@ -98,8 +98,8 @@ class MathWrapper {
         this.mathField = this.MQ.MathField(element, {
             // use a span instead of a textarea so that we don't bring up the
             // native keyboard on mobile when selecting the input
-            substituteTextarea: function() {
-                return document.createElement('span');
+            substituteTextarea: () => {
+                return this.fakeTextarea = document.createElement('span');
             },
         });
         this.callbacks = callbacks;

--- a/src/fake-react-native-web/view.js
+++ b/src/fake-react-native-web/view.js
@@ -88,6 +88,7 @@ const View = React.createClass({
                         clientX: e.clientX,
                         clientY: e.clientY,
                     }];
+                    e.isMouseEvent = true;
                 };
 
                 const doc = this._div.ownerDocument;


### PR DESCRIPTION
Add basic support for mouseevents and keyboardevents.

We've been using these changes written originally by @allofthenorthwood and @spicyj in our build of perseus, but i'm porting them to the source files so i can stop working in the compiled perseus.js compiled file. I'm guessing they're probably good/useful for KA too.

CC @spicyj @crm416 