### PR TITLE
re-add FRAC_INCLUSIVE, FRAC_EXCLUSIVE, and FRAC_MULTI keys to support mobile native

### DIFF
--- a/src/components/input/math-wrapper.js
+++ b/src/components/input/math-wrapper.js
@@ -51,6 +51,9 @@ const KeyActions = {
     [Keys.GEQ]: {str: '\\geq', fn: WRITE},
     [Keys.UP]: {str: 'Up', fn: KEYSTROKE},
     [Keys.DOWN]: {str: 'Down', fn: KEYSTROKE},
+    // The `FRAC_EXCLUSIVE` variant is handled manually, since we may need to do
+    // some additional navigation depending on the cursor position.
+    [Keys.FRAC_INCLUSIVE]: {str: '/', fn: CMD},
 };
 
 const NormalCommands = {
@@ -144,6 +147,14 @@ class MathWrapper {
             }
         } else if (Object.keys(NormalCommands).includes(key)) {
             this._writeNormalFunction(NormalCommands[key]);
+        } else if (key === Keys.FRAC_EXCLUSIVE) {
+            // If there's nothing to the left of the cursor, then we want to
+            // leave the cursor to the left of the fraction after creating it.
+            const shouldNavigateLeft = cursor[this.MQ.L] === MQ_END;
+            this.mathField.cmd('\\frac');
+            if (shouldNavigateLeft) {
+                this.mathField.keystroke('Left');
+            }
         } else if (key === Keys.FRAC) {
             const shouldNavigateLeft = cursor[this.MQ.L] === MQ_END;
             this.mathField.cmd('\\frac');

--- a/src/data/key-configs.js
+++ b/src/data/key-configs.js
@@ -84,6 +84,21 @@ const KeyConfigs = {
         type: KeyTypes.OPERATOR,
         ariaLabel: i18n._('Less than or equal to sign'),
     },
+    // mobile native
+    [Keys.FRAC_INCLUSIVE]: {
+        type: KeyTypes.OPERATOR,
+        // I18N: A label for a button that creates a new fraction and puts the
+        // current expression in the numerator of that fraction.
+        ariaLabel: i18n._('Fraction, with current expression in numerator'),
+    },
+    // mobile native
+    [Keys.FRAC_EXCLUSIVE]: {
+        type: KeyTypes.OPERATOR,
+        // I18N: A label for a button that creates a new fraction next to the
+        // cursor.
+        ariaLabel: i18n._('Fraction, excluding the current expression'),
+    },
+    // mobile web
     [Keys.FRAC]: {
         type: KeyTypes.OPERATOR,
         // I18N: A label for a button that creates a new fraction next to the
@@ -227,6 +242,16 @@ const KeyConfigs = {
         // I18N: A label for a button that will dismiss/hide a keypad.
         ariaLabel: i18n._('Dismiss'),
     },
+};
+
+// Add in any multi-function buttons. By default, these keys will mix in any
+// configuration settings from their default child key (i.e., the first key in
+// the `childKeyIds` array).
+// TODO(charlie): Make the multi-function button's long-press interaction
+// accessible.
+// NOTE(kevinb): This is only used in the mobile native app.
+KeyConfigs[Keys.FRAC_MULTI] = {
+    childKeyIds: [Keys.FRAC_INCLUSIVE, Keys.FRAC_EXCLUSIVE],
 };
 
 // TODO(charlie): Use the numeral color for the 'Many' key.

--- a/src/data/keys.js
+++ b/src/data/keys.js
@@ -22,6 +22,8 @@ const Keys = {
     LT: 'LT',
     GEQ: 'GEQ',
     LEQ: 'LEQ',
+    FRAC_INCLUSIVE: 'FRAC_INCLUSIVE', // mobile native only
+    FRAC_EXCLUSIVE: 'FRAC_EXCLUSIVE', // mobile native only
     FRAC: 'FRAC',
     EXP: 'EXP',
     EXP_2: 'EXP_2',
@@ -57,6 +59,9 @@ const Keys = {
     JUMP_OUT_DENOMINATOR: 'JUMP_OUT_DENOMINATOR',
 
     NOOP: 'NOOP',
+
+    // Multi-functional keys.
+    FRAC_MULTI: 'FRAC_MULTI', // mobile native only
 
     // A custom key that captures an arbitrary number of symbols but has no
     // 'default' symbol or action.


### PR DESCRIPTION
The mobile native applications still use the old style of fraction input.  This PR re-adds those keys in order to fix entering fractions on those platforms.

Test Plan:
- generate a build file by running `node_modules/webpack/bin/webpack.js --config webpack.config.externals.js`
- copy file to third_party/javascript-khansrc/math-input in webapp repo
- start mobile app from XCode
- start webapp
- point mobile app to localhost:8080 from settings application in simulator
- do some fractions questions in the app and see that all of the fraction keys on the on-screen keypad work properly
- verify that the current fraction key mobile web still works by entering a mixed fraction on localhost

<img width="394" alt="screen shot 2019-01-05 at 2 08 49 pm" src="https://user-images.githubusercontent.com/1044413/50728190-08f74c00-10f4-11e9-805c-65a25c099732.png">
<img width="400" alt="screen shot 2019-01-05 at 2 08 27 pm" src="https://user-images.githubusercontent.com/1044413/50728191-08f74c00-10f4-11e9-92de-0861a37838b2.png">
<img width="400" alt="screen shot 2019-01-05 at 2 15 28 pm" src="https://user-images.githubusercontent.com/1044413/50728227-8327d080-10f4-11e9-82aa-09704778a204.png">
