### PR TITLE
Give math input keyboard logical focus order

### DIFF
--- a/src/components/expression-keypad.js
+++ b/src/components/expression-keypad.js
@@ -4,10 +4,10 @@
 
 const React = require('react');
 const PropTypes = require('prop-types');
-const { connect } = require('react-redux');
-const { StyleSheet } = require('aphrodite');
+const {connect} = require('react-redux');
+const {StyleSheet} = require('aphrodite');
 
-const { View } = require('../fake-react-native-web');
+const {View} = require('../fake-react-native-web');
 const TwoPageKeypad = require('./two-page-keypad');
 const ManyKeypadButton = require('./many-keypad-button');
 const TouchableKeypadButton = require('./touchable-keypad-button');
@@ -23,9 +23,9 @@ const {
     keyCenter,
     keyRight,
 } = require('./styles');
-const { BorderStyles } = require('../consts');
-const { valueGrey, controlGrey } = require('./common-style');
-const { cursorContextPropType, keyIdPropType } = require('./prop-types');
+const {BorderStyles} = require('../consts');
+const {valueGrey, controlGrey} = require('./common-style');
+const {cursorContextPropType, keyIdPropType} = require('./prop-types');
 const KeyConfigs = require('../data/key-configs');
 const CursorContexts = require('./input/cursor-contexts');
 
@@ -36,7 +36,7 @@ class ExpressionKeypad extends React.Component {
         dynamicJumpOut: PropTypes.bool,
         extraKeys: PropTypes.arrayOf(keyIdPropType),
         roundTopLeft: PropTypes.bool,
-        roundTopRight: PropTypes.bool
+        roundTopRight: PropTypes.bool,
     };
 
     static rows = 4;
@@ -56,7 +56,7 @@ class ExpressionKeypad extends React.Component {
             dynamicJumpOut,
             extraKeys,
             roundTopLeft,
-            roundTopRight
+            roundTopRight,
         } = this.props;
 
         let dismissOrJumpOutKey;
@@ -212,7 +212,7 @@ class ExpressionKeypad extends React.Component {
             column,
             fullWidth,
             styles.leftPage,
-            roundTopLeft && roundedTopLeft
+            roundTopLeft && roundedTopLeft,
         ];
         const leftPage = (
             <View style={leftPageStyle}>
@@ -321,13 +321,11 @@ class ExpressionKeypad extends React.Component {
             </View>
         );
 
-        return (
-            <TwoPageKeypad
-                currentPage={currentPage}
-                rightPage={rightPage}
-                leftPage={leftPage}
-            />
-        );
+        return <TwoPageKeypad
+            currentPage={currentPage}
+            rightPage={rightPage}
+            leftPage={leftPage}
+        />;
     }
 }
 
@@ -338,19 +336,19 @@ const styles = StyleSheet.create({
     // dismiss).
     // TODO(charlie): Apply the proper background between the 'command' keys.
     rightPage: {
-        backgroundColor: valueGrey
+        backgroundColor: valueGrey,
     },
 
     leftPage: {
-        backgroundColor: controlGrey
+        backgroundColor: controlGrey,
     },
 });
 
-const mapStateToProps = state => {
+const mapStateToProps = (state) => {
     return {
         currentPage: state.pager.currentPage,
         cursorContext: state.input.cursor.context,
-        dynamicJumpOut: !state.layout.navigationPadEnabled
+        dynamicJumpOut: !state.layout.navigationPadEnabled,
     };
 };
 

--- a/src/components/expression-keypad.js
+++ b/src/components/expression-keypad.js
@@ -4,10 +4,10 @@
 
 const React = require('react');
 const PropTypes = require('prop-types');
-const {connect} = require('react-redux');
-const {StyleSheet} = require('aphrodite');
+const { connect } = require('react-redux');
+const { StyleSheet } = require('aphrodite');
 
-const {View} = require('../fake-react-native-web');
+const { View } = require('../fake-react-native-web');
 const TwoPageKeypad = require('./two-page-keypad');
 const ManyKeypadButton = require('./many-keypad-button');
 const TouchableKeypadButton = require('./touchable-keypad-button');
@@ -18,10 +18,14 @@ const {
     fullWidth,
     roundedTopLeft,
     roundedTopRight,
+    reverseColumn,
+    keyLeft,
+    keyCenter,
+    keyRight,
 } = require('./styles');
-const {BorderStyles} = require('../consts');
-const {valueGrey, controlGrey} = require('./common-style');
-const {cursorContextPropType, keyIdPropType} = require('./prop-types');
+const { BorderStyles } = require('../consts');
+const { valueGrey, controlGrey } = require('./common-style');
+const { cursorContextPropType, keyIdPropType } = require('./prop-types');
 const KeyConfigs = require('../data/key-configs');
 const CursorContexts = require('./input/cursor-contexts');
 
@@ -32,7 +36,7 @@ class ExpressionKeypad extends React.Component {
         dynamicJumpOut: PropTypes.bool,
         extraKeys: PropTypes.arrayOf(keyIdPropType),
         roundTopLeft: PropTypes.bool,
-        roundTopRight: PropTypes.bool,
+        roundTopRight: PropTypes.bool
     };
 
     static rows = 4;
@@ -52,7 +56,7 @@ class ExpressionKeypad extends React.Component {
             dynamicJumpOut,
             extraKeys,
             roundTopLeft,
-            roundTopRight,
+            roundTopRight
         } = this.props;
 
         let dismissOrJumpOutKey;
@@ -91,204 +95,239 @@ class ExpressionKeypad extends React.Component {
             dismissOrJumpOutKey = KeyConfigs.DISMISS;
         }
 
+        // list all the buttons in logical tab order
+
         const rightPageStyle = [
             row,
             fullWidth,
             styles.rightPage,
             roundTopRight && roundedTopRight,
         ];
-        const rightPage = <View style={rightPageStyle}>
-            <View style={[column, oneColumn]}>
-                <TouchableKeypadButton
-                    keyConfig={KeyConfigs.NUM_7}
-                    borders={BorderStyles.NONE}
-                />
-                <TouchableKeypadButton
-                    keyConfig={KeyConfigs.NUM_4}
-                    borders={BorderStyles.NONE}
-                />
-                <TouchableKeypadButton
-                    keyConfig={KeyConfigs.NUM_1}
-                    borders={BorderStyles.BOTTOM}
-                />
-                <ManyKeypadButton
-                    keys={extraKeys}
-                    borders={BorderStyles.NONE}
-                />
+        const rightPage = (
+            <View style={rightPageStyle}>
+                <View style={column}>
+                    <View style={reverseColumn}>
+                        <View style={row}>
+                            <TouchableKeypadButton
+                                keyConfig={KeyConfigs.NUM_1}
+                                borders={BorderStyles.BOTTOM}
+                            />
+                            <TouchableKeypadButton
+                                keyConfig={KeyConfigs.NUM_2}
+                                borders={BorderStyles.NONE}
+                            />
+                            <TouchableKeypadButton
+                                keyConfig={KeyConfigs.NUM_3}
+                                borders={BorderStyles.BOTTOM}
+                            />
+                        </View>
+                        <View style={row}>
+                            <TouchableKeypadButton
+                                keyConfig={KeyConfigs.NUM_4}
+                                borders={BorderStyles.NONE}
+                            />
+                            <TouchableKeypadButton
+                                keyConfig={KeyConfigs.NUM_5}
+                                borders={BorderStyles.NONE}
+                            />
+                            <TouchableKeypadButton
+                                keyConfig={KeyConfigs.NUM_6}
+                                borders={BorderStyles.NONE}
+                            />
+                        </View>
+                        <View style={row}>
+                            <TouchableKeypadButton
+                                keyConfig={KeyConfigs.NUM_7}
+                                borders={BorderStyles.NONE}
+                            />
+                            <TouchableKeypadButton
+                                keyConfig={KeyConfigs.NUM_8}
+                                borders={BorderStyles.NONE}
+                            />
+                            <TouchableKeypadButton
+                                keyConfig={KeyConfigs.NUM_9}
+                                borders={BorderStyles.NONE}
+                            />
+                        </View>
+                    </View>
+                    <View style={row}>
+                        <TouchableKeypadButton
+                            keyConfig={KeyConfigs.NUM_0}
+                            borders={BorderStyles.LEFT}
+                            style={keyCenter}
+                        />
+                        <TouchableKeypadButton
+                            keyConfig={KeyConfigs.DECIMAL}
+                            borders={BorderStyles.LEFT}
+                            style={keyRight}
+                        />
+                        <ManyKeypadButton
+                            keys={extraKeys}
+                            borders={BorderStyles.NONE}
+                            style={keyLeft}
+                        />
+                    </View>
+                </View>
+                <View style={[reverseColumn, oneColumn]}>
+                    <TouchableKeypadButton
+                        keyConfig={KeyConfigs.PLUS}
+                        borders={BorderStyles.LEFT}
+                    />
+                    <TouchableKeypadButton
+                        keyConfig={KeyConfigs.MINUS}
+                        borders={BorderStyles.LEFT}
+                    />
+                    <TouchableKeypadButton
+                        keyConfig={KeyConfigs.TIMES}
+                        borders={BorderStyles.LEFT}
+                    />
+                    <TouchableKeypadButton
+                        keyConfig={KeyConfigs.DIVIDE}
+                        borders={BorderStyles.LEFT}
+                    />
+                </View>
+                <View style={[column, oneColumn]}>
+                    <View style={[column, oneColumn]}>
+                        <TouchableKeypadButton
+                            keyConfig={KeyConfigs.FRAC}
+                            style={roundTopRight && roundedTopRight}
+                        />
+                        <TouchableKeypadButton keyConfig={KeyConfigs.CDOT} />
+                    </View>
+                    <View style={[column, oneColumn]}>
+                        <TouchableKeypadButton
+                            keyConfig={KeyConfigs.BACKSPACE}
+                            borders={BorderStyles.LEFT}
+                        />
+                        <TouchableKeypadButton
+                            keyConfig={dismissOrJumpOutKey}
+                            borders={BorderStyles.LEFT}
+                        />
+                    </View>
+                </View>
             </View>
-            <View style={[column, oneColumn]}>
-                <TouchableKeypadButton
-                    keyConfig={KeyConfigs.NUM_8}
-                    borders={BorderStyles.NONE}
-                />
-                <TouchableKeypadButton
-                    keyConfig={KeyConfigs.NUM_5}
-                    borders={BorderStyles.NONE}
-                />
-                <TouchableKeypadButton
-                    keyConfig={KeyConfigs.NUM_2}
-                    borders={BorderStyles.NONE}
-                />
-                <TouchableKeypadButton
-                    keyConfig={KeyConfigs.NUM_0}
-                    borders={BorderStyles.LEFT}
-                />
-            </View>
-            <View style={[column, oneColumn]}>
-                <TouchableKeypadButton
-                    keyConfig={KeyConfigs.NUM_9}
-                    borders={BorderStyles.NONE}
-                />
-                <TouchableKeypadButton
-                    keyConfig={KeyConfigs.NUM_6}
-                    borders={BorderStyles.NONE}
-                />
-                <TouchableKeypadButton
-                    keyConfig={KeyConfigs.NUM_3}
-                    borders={BorderStyles.BOTTOM}
-                />
-                <TouchableKeypadButton
-                    keyConfig={KeyConfigs.DECIMAL}
-                    borders={BorderStyles.LEFT}
-                />
-            </View>
-            <View style={[column, oneColumn]}>
-                <TouchableKeypadButton
-                    keyConfig={KeyConfigs.DIVIDE}
-                    borders={BorderStyles.LEFT}
-                />
-                <TouchableKeypadButton
-                    keyConfig={KeyConfigs.TIMES}
-                    borders={BorderStyles.LEFT}
-                />
-                <TouchableKeypadButton
-                    keyConfig={KeyConfigs.MINUS}
-                    borders={BorderStyles.LEFT}
-                />
-                <TouchableKeypadButton
-                    keyConfig={KeyConfigs.PLUS}
-                    borders={BorderStyles.LEFT}
-                />
-            </View>
-            <View style={[column, oneColumn]}>
-                <TouchableKeypadButton
-                    keyConfig={KeyConfigs.FRAC}
-                    style={roundTopRight && roundedTopRight}
-                />
-                <TouchableKeypadButton keyConfig={KeyConfigs.CDOT} />
-                <TouchableKeypadButton
-                    keyConfig={KeyConfigs.BACKSPACE}
-                    borders={BorderStyles.LEFT}
-                />
-                <TouchableKeypadButton
-                    keyConfig={dismissOrJumpOutKey}
-                    borders={BorderStyles.LEFT}
-                />
-            </View>
-        </View>;
+        );
 
         const leftPageStyle = [
-            row,
+            column,
             fullWidth,
             styles.leftPage,
-            roundTopLeft && roundedTopLeft,
+            roundTopLeft && roundedTopLeft
         ];
-        const leftPage = <View style={leftPageStyle}>
-            <View style={[column, oneColumn]}>
-                <TouchableKeypadButton
-                    keyConfig={KeyConfigs.EXP_2}
-                    borders={BorderStyles.NONE}
-                    style={roundTopLeft && roundedTopLeft}
-                />
-                <TouchableKeypadButton
-                    keyConfig={KeyConfigs.SQRT}
-                    borders={BorderStyles.NONE}
-                />
-                <TouchableKeypadButton
-                    keyConfig={KeyConfigs.LOG}
-                    borders={BorderStyles.BOTTOM}
-                />
-                <TouchableKeypadButton
-                    keyConfig={KeyConfigs.SIN}
-                    borders={BorderStyles.NONE}
-                />
+        const leftPage = (
+            <View style={leftPageStyle}>
+                <View style={row}>
+                    <View style={column}>
+                        <View style={row}>
+                            <TouchableKeypadButton
+                                keyConfig={KeyConfigs.EXP_2}
+                                borders={BorderStyles.NONE}
+                                style={roundTopLeft && roundedTopLeft}
+                            />
+                            <TouchableKeypadButton
+                                keyConfig={KeyConfigs.EXP_3}
+                                borders={BorderStyles.NONE}
+                            />
+                            <TouchableKeypadButton
+                                keyConfig={KeyConfigs.EXP}
+                                borders={BorderStyles.NONE}
+                            />
+                        </View>
+                        <View style={row}>
+                            <TouchableKeypadButton
+                                keyConfig={KeyConfigs.SQRT}
+                                borders={BorderStyles.NONE}
+                            />
+                            <TouchableKeypadButton
+                                keyConfig={KeyConfigs.CUBE_ROOT}
+                                borders={BorderStyles.NONE}
+                            />
+                            <TouchableKeypadButton
+                                keyConfig={KeyConfigs.RADICAL}
+                                borders={BorderStyles.NONE}
+                            />
+                        </View>
+                        <View style={row}>
+                            <TouchableKeypadButton
+                                keyConfig={KeyConfigs.LOG}
+                                borders={BorderStyles.BOTTOM}
+                            />
+                            <TouchableKeypadButton
+                                keyConfig={KeyConfigs.LN}
+                                borders={BorderStyles.BOTTOM}
+                            />
+                            <TouchableKeypadButton
+                                keyConfig={KeyConfigs.LOG_N}
+                                borders={BorderStyles.BOTTOM}
+                            />
+                        </View>
+                    </View>
+                    <View style={column}>
+                        <View style={row}>
+                            <TouchableKeypadButton
+                                keyConfig={KeyConfigs.GEQ}
+                                borders={BorderStyles.LEFT}
+                            />
+                            <TouchableKeypadButton
+                                keyConfig={KeyConfigs.GT}
+                                borders={BorderStyles.NONE}
+                            />
+                        </View>
+                        <View style={row}>
+                            <TouchableKeypadButton
+                                keyConfig={KeyConfigs.EQUAL}
+                                borders={BorderStyles.LEFT}
+                            />
+                            <TouchableKeypadButton
+                                keyConfig={KeyConfigs.NEQ}
+                                borders={BorderStyles.NONE}
+                            />
+                        </View>
+                        <View style={row}>
+                            <TouchableKeypadButton keyConfig={KeyConfigs.LEQ} />
+                            <TouchableKeypadButton
+                                keyConfig={KeyConfigs.LT}
+                                borders={BorderStyles.BOTTOM}
+                            />
+                        </View>
+                    </View>
+                </View>
+                <View style={row}>
+                    <View style={row}>
+                        <TouchableKeypadButton
+                            keyConfig={KeyConfigs.SIN}
+                            borders={BorderStyles.NONE}
+                        />
+                        <TouchableKeypadButton
+                            keyConfig={KeyConfigs.COS}
+                            borders={BorderStyles.NONE}
+                        />
+                        <TouchableKeypadButton
+                            keyConfig={KeyConfigs.TAN}
+                            borders={BorderStyles.NONE}
+                        />
+                    </View>
+                    <View style={row}>
+                        <TouchableKeypadButton
+                            keyConfig={KeyConfigs.LEFT_PAREN}
+                            borders={BorderStyles.LEFT}
+                        />
+                        <TouchableKeypadButton
+                            keyConfig={KeyConfigs.RIGHT_PAREN}
+                            borders={BorderStyles.NONE}
+                        />
+                    </View>
+                </View>
             </View>
-            <View style={[column, oneColumn]}>
-                <TouchableKeypadButton
-                    keyConfig={KeyConfigs.EXP_3}
-                    borders={BorderStyles.NONE}
-                />
-                <TouchableKeypadButton
-                    keyConfig={KeyConfigs.CUBE_ROOT}
-                    borders={BorderStyles.NONE}
-                />
-                <TouchableKeypadButton
-                    keyConfig={KeyConfigs.LN}
-                    borders={BorderStyles.BOTTOM}
-                />
-                <TouchableKeypadButton
-                    keyConfig={KeyConfigs.COS}
-                    borders={BorderStyles.NONE}
-                />
-            </View>
-            <View style={[column, oneColumn]}>
-                <TouchableKeypadButton
-                    keyConfig={KeyConfigs.EXP}
-                    borders={BorderStyles.NONE}
-                />
-                <TouchableKeypadButton
-                    keyConfig={KeyConfigs.RADICAL}
-                    borders={BorderStyles.NONE}
-                />
-                <TouchableKeypadButton
-                    keyConfig={KeyConfigs.LOG_N}
-                    borders={BorderStyles.BOTTOM}
-                />
-                <TouchableKeypadButton
-                    keyConfig={KeyConfigs.TAN}
-                    borders={BorderStyles.NONE}
-                />
-            </View>
-            <View style={[column, oneColumn]}>
-                <TouchableKeypadButton
-                    keyConfig={KeyConfigs.GEQ}
-                    borders={BorderStyles.LEFT}
-                />
-                <TouchableKeypadButton
-                    keyConfig={KeyConfigs.EQUAL}
-                    borders={BorderStyles.LEFT}
-                />
-                <TouchableKeypadButton keyConfig={KeyConfigs.LEQ} />
-                <TouchableKeypadButton
-                    keyConfig={KeyConfigs.LEFT_PAREN}
-                    borders={BorderStyles.LEFT}
-                />
-            </View>
-            <View style={[column, oneColumn]}>
-                <TouchableKeypadButton
-                    keyConfig={KeyConfigs.GT}
-                    borders={BorderStyles.NONE}
-                />
-                <TouchableKeypadButton
-                    keyConfig={KeyConfigs.NEQ}
-                    borders={BorderStyles.NONE}
-                />
-                <TouchableKeypadButton
-                    keyConfig={KeyConfigs.LT}
-                    borders={BorderStyles.BOTTOM}
-                />
-                <TouchableKeypadButton
-                    keyConfig={KeyConfigs.RIGHT_PAREN}
-                    borders={BorderStyles.NONE}
-                />
-            </View>
-        </View>;
+        );
 
-        return <TwoPageKeypad
-            currentPage={currentPage}
-            rightPage={rightPage}
-            leftPage={leftPage}
-        />;
+        return (
+            <TwoPageKeypad
+                currentPage={currentPage}
+                rightPage={rightPage}
+                leftPage={leftPage}
+            />
+        );
     }
 }
 
@@ -299,19 +338,19 @@ const styles = StyleSheet.create({
     // dismiss).
     // TODO(charlie): Apply the proper background between the 'command' keys.
     rightPage: {
-        backgroundColor: valueGrey,
+        backgroundColor: valueGrey
     },
 
     leftPage: {
-        backgroundColor: controlGrey,
+        backgroundColor: controlGrey
     },
 });
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
     return {
         currentPage: state.pager.currentPage,
         cursorContext: state.input.cursor.context,
-        dynamicJumpOut: !state.layout.navigationPadEnabled,
+        dynamicJumpOut: !state.layout.navigationPadEnabled
     };
 };
 

--- a/src/components/fraction-keypad.js
+++ b/src/components/fraction-keypad.js
@@ -5,9 +5,9 @@
 
 const React = require('react');
 const PropTypes = require('prop-types');
-const { connect } = require('react-redux');
+const {connect} = require('react-redux');
 
-const { View } = require('../fake-react-native-web');
+const {View} = require('../fake-react-native-web');
 const Keypad = require('./keypad');
 const TouchableKeypadButton = require('./touchable-keypad-button');
 const {
@@ -21,9 +21,9 @@ const {
     keyCenter,
     keyRight
 } = require('./styles');
-const { BorderStyles } = require('../consts');
+const {BorderStyles} = require('../consts');
 const CursorContexts = require('./input/cursor-contexts');
-const { cursorContextPropType } = require('./prop-types');
+const {cursorContextPropType} = require('./prop-types');
 const KeyConfigs = require('../data/key-configs');
 
 class FractionKeypad extends React.Component {
@@ -31,7 +31,7 @@ class FractionKeypad extends React.Component {
         cursorContext: cursorContextPropType.isRequired,
         dynamicJumpOut: PropTypes.bool,
         roundTopLeft: PropTypes.bool,
-        roundTopRight: PropTypes.bool
+        roundTopRight: PropTypes.bool,
     };
 
     static rows = 4;
@@ -49,7 +49,7 @@ class FractionKeypad extends React.Component {
             cursorContext,
             dynamicJumpOut,
             roundTopLeft,
-            roundTopRight
+            roundTopRight,
         } = this.props;
 
         let dismissOrJumpOutKey;
@@ -194,10 +194,10 @@ class FractionKeypad extends React.Component {
     }
 }
 
-const mapStateToProps = state => {
+const mapStateToProps = (state) => {
     return {
         cursorContext: state.input.cursor.context,
-        dynamicJumpOut: !state.layout.navigationPadEnabled
+        dynamicJumpOut: !state.layout.navigationPadEnabled,
     };
 };
 

--- a/src/components/fraction-keypad.js
+++ b/src/components/fraction-keypad.js
@@ -5,15 +5,25 @@
 
 const React = require('react');
 const PropTypes = require('prop-types');
-const {connect} = require('react-redux');
+const { connect } = require('react-redux');
 
-const {View} = require('../fake-react-native-web');
+const { View } = require('../fake-react-native-web');
 const Keypad = require('./keypad');
 const TouchableKeypadButton = require('./touchable-keypad-button');
-const {row, roundedTopLeft, roundedTopRight} = require('./styles');
-const {BorderStyles} = require('../consts');
+const {
+    row,
+    column,
+    oneColumn,
+    reverseColumn,
+    roundedTopLeft,
+    roundedTopRight,
+    keyLeft,
+    keyCenter,
+    keyRight
+} = require('./styles');
+const { BorderStyles } = require('../consts');
 const CursorContexts = require('./input/cursor-contexts');
-const {cursorContextPropType} = require('./prop-types');
+const { cursorContextPropType } = require('./prop-types');
 const KeyConfigs = require('../data/key-configs');
 
 class FractionKeypad extends React.Component {
@@ -21,7 +31,7 @@ class FractionKeypad extends React.Component {
         cursorContext: cursorContextPropType.isRequired,
         dynamicJumpOut: PropTypes.bool,
         roundTopLeft: PropTypes.bool,
-        roundTopRight: PropTypes.bool,
+        roundTopRight: PropTypes.bool
     };
 
     static rows = 4;
@@ -39,7 +49,7 @@ class FractionKeypad extends React.Component {
             cursorContext,
             dynamicJumpOut,
             roundTopLeft,
-            roundTopRight,
+            roundTopRight
         } = this.props;
 
         let dismissOrJumpOutKey;
@@ -78,95 +88,116 @@ class FractionKeypad extends React.Component {
             dismissOrJumpOutKey = KeyConfigs.DISMISS;
         }
 
-        return <Keypad>
-            <View style={row}>
-                <TouchableKeypadButton
-                    keyConfig={KeyConfigs.NUM_7}
-                    borders={BorderStyles.NONE}
-                    style={roundTopLeft && roundedTopLeft}
-                />
-                <TouchableKeypadButton
-                    keyConfig={KeyConfigs.NUM_8}
-                    borders={BorderStyles.NONE}
-                />
-                <TouchableKeypadButton
-                    keyConfig={KeyConfigs.NUM_9}
-                    borders={BorderStyles.NONE}
-                />
-                <TouchableKeypadButton
-                    keyConfig={KeyConfigs.FRAC}
-                    disabled={
-                        // NOTE(charlie): It's only sufficient to use
-                        // `IN_NUMERATOR` and `IN_DENOMINATOR` here because we
-                        // don't support parentheses in this keypad. If we did,
-                        // then when the cursor was inside a parenthetical
-                        // expression in a numerator or denominator, this check
-                        // would fail.
-                        cursorContext === CursorContexts.IN_NUMERATOR ||
-                        cursorContext === CursorContexts.IN_DENOMINATOR
-                    }
-                    style={roundTopRight && roundedTopRight}
-                />
-            </View>
-            <View style={row}>
-                <TouchableKeypadButton
-                    keyConfig={KeyConfigs.NUM_4}
-                    borders={BorderStyles.NONE}
-                />
-                <TouchableKeypadButton
-                    keyConfig={KeyConfigs.NUM_5}
-                    borders={BorderStyles.NONE}
-                />
-                <TouchableKeypadButton
-                    keyConfig={KeyConfigs.NUM_6}
-                    borders={BorderStyles.NONE}
-                />
-                <TouchableKeypadButton keyConfig={KeyConfigs.PERCENT} />
-            </View>
-            <View style={row}>
-                <TouchableKeypadButton
-                    keyConfig={KeyConfigs.NUM_1}
-                    borders={BorderStyles.BOTTOM}
-                />
-                <TouchableKeypadButton
-                    keyConfig={KeyConfigs.NUM_2}
-                    borders={BorderStyles.NONE}
-                />
-                <TouchableKeypadButton
-                    keyConfig={KeyConfigs.NUM_3}
-                    borders={BorderStyles.BOTTOM}
-                />
-                <TouchableKeypadButton
-                    keyConfig={KeyConfigs.BACKSPACE}
-                    borders={BorderStyles.LEFT}
-                />
-            </View>
-            <View style={row}>
-                <TouchableKeypadButton
-                    keyConfig={KeyConfigs.NEGATIVE}
-                    borders={BorderStyles.NONE}
-                />
-                <TouchableKeypadButton
-                    keyConfig={KeyConfigs.NUM_0}
-                    borders={BorderStyles.LEFT}
-                />
-                <TouchableKeypadButton
-                    keyConfig={KeyConfigs.DECIMAL}
-                    borders={BorderStyles.LEFT}
-                />
-                <TouchableKeypadButton
-                    keyConfig={dismissOrJumpOutKey}
-                    borders={BorderStyles.LEFT}
-                />
-            </View>
-        </Keypad>;
+        return (
+            <Keypad>
+                <View style={row}>
+                    <View style={column}>
+                        <View style={reverseColumn}>
+                            <View style={row}>
+                                <TouchableKeypadButton
+                                    keyConfig={KeyConfigs.NUM_1}
+                                    borders={BorderStyles.BOTTOM}
+                                />
+                                <TouchableKeypadButton
+                                    keyConfig={KeyConfigs.NUM_2}
+                                    borders={BorderStyles.NONE}
+                                />
+                                <TouchableKeypadButton
+                                    keyConfig={KeyConfigs.NUM_3}
+                                    borders={BorderStyles.BOTTOM}
+                                />
+                            </View>
+                            <View style={row}>
+                                <TouchableKeypadButton
+                                    keyConfig={KeyConfigs.NUM_4}
+                                    borders={BorderStyles.NONE}
+                                />
+                                <TouchableKeypadButton
+                                    keyConfig={KeyConfigs.NUM_5}
+                                    borders={BorderStyles.NONE}
+                                />
+                                <TouchableKeypadButton
+                                    keyConfig={KeyConfigs.NUM_6}
+                                    borders={BorderStyles.NONE}
+                                />
+                            </View>
+                            <View style={row}>
+                                <TouchableKeypadButton
+                                    keyConfig={KeyConfigs.NUM_7}
+                                    borders={BorderStyles.NONE}
+                                    style={roundTopLeft && roundedTopLeft}
+                                />
+                                <TouchableKeypadButton
+                                    keyConfig={KeyConfigs.NUM_8}
+                                    borders={BorderStyles.NONE}
+                                />
+                                <TouchableKeypadButton
+                                    keyConfig={KeyConfigs.NUM_9}
+                                    borders={BorderStyles.NONE}
+                                />
+                            </View>
+                        </View>
+                        <View style={row}>
+                            <TouchableKeypadButton
+                                keyConfig={KeyConfigs.NUM_0}
+                                borders={BorderStyles.LEFT}
+                                style={keyCenter}
+                            />
+                            <TouchableKeypadButton
+                                keyConfig={KeyConfigs.DECIMAL}
+                                borders={BorderStyles.LEFT}
+                                style={keyRight}
+                            />
+                            <TouchableKeypadButton
+                                keyConfig={KeyConfigs.NEGATIVE}
+                                borders={BorderStyles.NONE}
+                                style={keyLeft}
+                            />
+                        </View>
+                    </View>
+                    <View style={[column, oneColumn]}>
+                        <View style={[column, oneColumn]}>
+                            <TouchableKeypadButton
+                                keyConfig={KeyConfigs.FRAC}
+                                disabled={
+                                    // NOTE(charlie): It's only sufficient to use
+                                    // `IN_NUMERATOR` and `IN_DENOMINATOR` here because we
+                                    // don't support parentheses in this keypad. If we did,
+                                    // then when the cursor was inside a parenthetical
+                                    // expression in a numerator or denominator, this check
+                                    // would fail.
+                                    cursorContext ===
+                                        CursorContexts.IN_NUMERATOR ||
+                                    cursorContext ===
+                                        CursorContexts.IN_DENOMINATOR
+                                }
+                                style={roundTopRight && roundedTopRight}
+                            />
+                            <TouchableKeypadButton
+                                keyConfig={KeyConfigs.PERCENT}
+                            />
+                        </View>
+                        <View style={[column, oneColumn]}>
+                            <TouchableKeypadButton
+                                keyConfig={KeyConfigs.BACKSPACE}
+                                borders={BorderStyles.LEFT}
+                            />
+                            <TouchableKeypadButton
+                                keyConfig={dismissOrJumpOutKey}
+                                borders={BorderStyles.LEFT}
+                            />
+                        </View>
+                    </View>
+                </View>
+            </Keypad>
+        );
     }
 }
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
     return {
         cursorContext: state.input.cursor.context,
-        dynamicJumpOut: !state.layout.navigationPadEnabled,
+        dynamicJumpOut: !state.layout.navigationPadEnabled
     };
 };
 

--- a/src/components/keypad-button.js
+++ b/src/components/keypad-button.js
@@ -218,6 +218,7 @@ class KeypadButton extends React.PureComponent {
             const manyButtonA11yMarkup = {
                 role: 'button',
                 ariaLabel: childKeys[0].ariaLabel,
+                tabIndex: 0
             };
             const icons = childKeys.map(keyConfig => {
                 return keyConfig.icon;
@@ -237,6 +238,7 @@ class KeypadButton extends React.PureComponent {
             const a11yMarkup = {
                 role: 'button',
                 ariaLabel: ariaLabel,
+                tabIndex: 0
             };
 
             return <View style={buttonStyle} {...eventHandlers} {...a11yMarkup}>

--- a/src/components/keypad-container.js
+++ b/src/components/keypad-container.js
@@ -194,7 +194,7 @@ class KeypadContainer extends React.Component {
                 <View style={styles.keypadLayout}>
                     {this.renderKeypad()}
                 </View>
-                {navigationPadEnabled &&
+                {active && navigationPadEnabled &&
                     <NavigationPad
                         roundTopLeft={layoutMode === LayoutModes.COMPACT}
                         style={styles.navigationPadContainer}

--- a/src/components/keypad-container.js
+++ b/src/components/keypad-container.js
@@ -11,7 +11,7 @@ const zIndexes = require('./z-indexes');
 const {setPageSize} = require('../actions');
 const {keyIdPropType} = require('./prop-types');
 const {KeypadTypes, LayoutModes} = require('../consts');
-const {row, centered, fullWidth} = require('./styles');
+const {row, reverseRow, centered, fullWidth} = require('./styles');
 const {
     innerBorderColor,
     innerBorderStyle,
@@ -166,7 +166,7 @@ class KeypadContainer extends React.Component {
         ];
 
         const keypadStyle = [
-            row,
+            reverseRow,
             styles.keypadBorder,
             layoutMode === LayoutModes.FULLSCREEN ? styles.fullscreen
                                                   : styles.compact,
@@ -181,6 +181,8 @@ class KeypadContainer extends React.Component {
             extraClassName="keypad-container"
         >
             <View
+                // List in logical tab order for a11y and
+                // correct visual order with styling
                 style={keypadStyle}
                 ref={element => {
                     if (!this.hasMounted && element) {
@@ -189,15 +191,15 @@ class KeypadContainer extends React.Component {
                     }
                 }}
             >
+                <View style={styles.keypadLayout}>
+                    {this.renderKeypad()}
+                </View>
                 {navigationPadEnabled &&
                     <NavigationPad
                         roundTopLeft={layoutMode === LayoutModes.COMPACT}
                         style={styles.navigationPadContainer}
                     />
                 }
-                <View style={styles.keypadLayout}>
-                    {this.renderKeypad()}
-                </View>
             </View>
         </View>;
     }

--- a/src/components/keypad.js
+++ b/src/components/keypad.js
@@ -122,6 +122,9 @@ class Keypad extends React.Component {
         };
 
         return <View style={style}>
+            {/* a11y: Only render the children after keyboard has been
+            activated. Buttons should only be added to the DOM and be able to
+            receive focus if the keyboard is already active. */}
             {active && children}
             <EchoManager
                 echoes={relativeEchoes}

--- a/src/components/keypad.js
+++ b/src/components/keypad.js
@@ -83,6 +83,7 @@ class Keypad extends React.Component {
 
     render() {
         const {
+            active,
             children,
             echoes,
             removeEcho,
@@ -121,7 +122,7 @@ class Keypad extends React.Component {
         };
 
         return <View style={style}>
-            {children}
+            {active && children}
             <EchoManager
                 echoes={relativeEchoes}
                 onAnimationFinish={removeEcho}

--- a/src/components/styles.js
+++ b/src/components/styles.js
@@ -35,4 +35,19 @@ module.exports = StyleSheet.create({
     roundedTopRight: {
         borderTopRightRadius: compactKeypadBorderRadiusPx,
     },
+    reverseRow: {
+        flexDirection: 'row-reverse',
+    },
+    reverseColumn: {
+        flexDirection: 'column-reverse',
+    },
+    keyLeft: {
+        order: 1,
+    },
+    keyCenter: {
+        order: 2,
+    },
+    keyRight: {
+        order: 3,
+    }
 });

--- a/src/components/styles.js
+++ b/src/components/styles.js
@@ -41,6 +41,10 @@ module.exports = StyleSheet.create({
     reverseColumn: {
         flexDirection: 'column-reverse',
     },
+
+    // Styles for manually placing the keys in visual order even if
+    // they're not in the same logical DOM order.
+    // Specifically for a 3-column keypad.
     keyLeft: {
         order: 1,
     },

--- a/src/components/two-page-keypad.js
+++ b/src/components/two-page-keypad.js
@@ -44,6 +44,10 @@ class TwoPageKeypad extends React.Component {
             </Keypad>;
         } else {
             return <Keypad style={styles.keypad}>
+                {/* a11y: Put the right page before the left page in
+                the DOM so that the numbers (right page) receive focus
+                before the additional math keys (left page) in the tab
+                order. */}
                 <View style={reverseRow}>
                     <View style={[styles.borderLeft, fullWidth]}>
                         {rightPage}

--- a/src/components/two-page-keypad.js
+++ b/src/components/two-page-keypad.js
@@ -11,7 +11,7 @@ const Keypad = require('./keypad');
 const ViewPager = require('./view-pager');
 const PagerIndicator = require('./pager-indicator');
 const {View} = require('../fake-react-native-web');
-const {column, row, fullWidth} = require('./styles');
+const {column, reverseRow, fullWidth} = require('./styles');
 const {
     innerBorderColor, innerBorderStyle, innerBorderWidthPx, gray85,
 } = require('./common-style');
@@ -44,12 +44,12 @@ class TwoPageKeypad extends React.Component {
             </Keypad>;
         } else {
             return <Keypad style={styles.keypad}>
-                <View style={row}>
-                    <View style={fullWidth}>
-                        {leftPage}
-                    </View>
+                <View style={reverseRow}>
                     <View style={[styles.borderLeft, fullWidth]}>
                         {rightPage}
+                    </View>
+                    <View style={fullWidth}>
+                        {leftPage}
                     </View>
                 </View>
             </Keypad>;

--- a/src/components/view-pager.js
+++ b/src/components/view-pager.js
@@ -11,7 +11,7 @@ const {connect} = require('react-redux');
 const {StyleSheet} = require('aphrodite');
 
 const {View} = require('../fake-react-native-web');
-const {row} = require('./styles');
+const {reverseRow} = require('./styles');
 const {childrenPropType} = require('./prop-types');
 const {
     innerBorderColor,
@@ -55,7 +55,7 @@ class ViewPager extends React.Component {
         const {children, pageWidthPx, translateX} = this.props;
         const {animationDurationMs} = this.state;
 
-        const pagerStyle = [row, styles.twoPagePager];
+        const pagerStyle = [reverseRow, styles.twoPagePager];
 
         const transform = {
             msTransform: `translate3d(${translateX}px, 0, 0)`,
@@ -83,11 +83,12 @@ class ViewPager extends React.Component {
         };
 
         return <View style={pagerStyle} dynamicStyle={dynamicPagerStyle}>
+            {/* list the number keypad page first for tab order */}
             <View dynamicStyle={dynamicPageStyle}>
-                {children[0]}
+                {children[1]}
             </View>
             <View style={styles.rightPage} dynamicStyle={dynamicPageStyle}>
-                {children[1]}
+                {children[0]}
             </View>
         </View>;
     }

--- a/src/fake-react-native-web/view.js
+++ b/src/fake-react-native-web/view.js
@@ -28,6 +28,7 @@ class View extends React.Component {
         onTouchStart: PropTypes.func,
         role: PropTypes.string,
         style: PropTypes.any,
+        tabIndex: PropTypes.number,
     };
 
     static styles = StyleSheet.create({
@@ -75,6 +76,7 @@ class View extends React.Component {
             onTouchStart={this.props.onTouchStart}
             aria-label={this.props.ariaLabel}
             role={this.props.role}
+            tabIndex={this.props.tabIndex}
         >
             {this.props.children}
         </div>;


### PR DESCRIPTION
Summary:
- Gave all keys tabIndex 0 so they can be in focus
- Reordered keys so they're listed in tab order
- Used CSS to make the keys appear in the right place visually

Issue: https://khanacademy.atlassian.net/browse/LP-7269