### PR TITLE
Hardware keyboard input

### DIFF
--- a/src/components/input/math-input.js
+++ b/src/components/input/math-input.js
@@ -304,7 +304,6 @@ class MathInput extends React.Component {
     focus = () => {
         // Pass this component's handleKey method to the keypad so it can call
         // it whenever it needs to trigger a keypress action.
-        // BLAH
         this.props.keypadElement.setKeyHandler(key => {
             const cursor = this.mathField.pressKey(key);
 
@@ -747,6 +746,7 @@ class MathInput extends React.Component {
             if (this.props.value !== value) {
                 this.mathField.setContent(this.props.value);
                 this.props.onChange(value, false);
+                this._hideCursorHandle();
             }
         }
     };      

--- a/src/components/input/math-input.js
+++ b/src/components/input/math-input.js
@@ -699,32 +699,22 @@ class MathInput extends React.Component {
     };
 
     domKeyToMathQuillKey = (key) => {
+        const keyMap = {
+            "+": Keys.PLUS,
+            "-": Keys.MINUS,
+            "*": Keys.TIMES,
+            "/": Keys.DIVIDE,
+            ".": Keys.DECIMAL,
+            "%": Keys.PERCENT,
+            "=": Keys.EQUAL,
+            ">": Keys.GT,
+            "<": Keys.LT,
+            "^": Keys.EXP
+        };
+
         // Numbers
         if (['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'].includes(key)){
             return `NUM_${key}`;
-        } 
-
-        // Operators
-        else if (key == "+"){
-            return Keys.PLUS;
-        } else if (key == "-"){
-            return Keys.MINUS;
-        } else if (key == "*"){
-            return Keys.TIMES;
-        } else if (key == "/"){
-            return Keys.DIVIDE;
-        } else if (key == "."){
-            return Keys.DECIMAL;
-        } else if (key == "%"){
-            return Keys.PERCENT;
-        } else if (key == "="){
-            return Keys.EQUAL;
-        } else if (key == ">"){
-            return Keys.GT;
-        } else if (key == "<"){
-            return Keys.LT;
-        } else if (key == "^"){
-            return Keys.EXP;
         }
 
         // Movement keys
@@ -732,11 +722,17 @@ class MathInput extends React.Component {
             return Keys.BACKSPACE
         }
 
+        // Operators
+        else if (key in keyMap){
+             return keyMap[key];
+
+        }
+
         // The key pressed doesn't map to any of the math input operators
         return null;
     }
 
-    handleKeyPress = (event) => {
+    handleKeyUp = (event) => {
         const mathQuillKey = this.domKeyToMathQuillKey(event.key);
 
         if (mathQuillKey){
@@ -807,7 +803,7 @@ class MathInput extends React.Component {
                 ref={node => {
                     this.inputRef = node;
                 }}
-                onKeyUp={this.handleKeyPress}
+                onKeyUp={this.handleKeyUp}
             >
                 {/* NOTE(charlie): This element must be styled with inline
                     styles rather than with Aphrodite classes, as MathQuill

--- a/src/components/input/math-input.js
+++ b/src/components/input/math-input.js
@@ -15,6 +15,7 @@ const {
  } = require('../common-style');
 const {keypadElementPropType} = require('../prop-types');
 const {brightGreen, gray17} = require('../common-style');
+const Keys = require("../../data/keys");
 
 const i18n = window.i18n || {_: s => s};
 
@@ -303,6 +304,7 @@ class MathInput extends React.Component {
     focus = () => {
         // Pass this component's handleKey method to the keypad so it can call
         // it whenever it needs to trigger a keypress action.
+        // BLAH
         this.props.keypadElement.setKeyHandler(key => {
             const cursor = this.mathField.pressKey(key);
 
@@ -697,6 +699,58 @@ class MathInput extends React.Component {
         this._updateCursorHandle(true);
     };
 
+    domKeyToMathQuillKey = (key) => {
+        // Numbers
+        if (['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'].includes(key)){
+            return `NUM_${key}`;
+        } 
+
+        // Operators
+        else if (key == "+"){
+            return Keys.PLUS;
+        } else if (key == "-"){
+            return Keys.MINUS;
+        } else if (key == "*"){
+            return Keys.TIMES;
+        } else if (key == "/"){
+            return Keys.DIVIDE;
+        } else if (key == "."){
+            return Keys.DECIMAL;
+        } else if (key == "%"){
+            return Keys.PERCENT;
+        } else if (key == "="){
+            return Keys.EQUAL;
+        } else if (key == ">"){
+            return Keys.GT;
+        } else if (key == "<"){
+            return Keys.LT;
+        } else if (key == "^"){
+            return Keys.EXP;
+        }
+
+        // Movement keys
+        else if (key == "Backspace"){
+            return Keys.BACKSPACE
+        }
+
+        // The key pressed doesn't map to any of the math input operators
+        return null;
+    }
+
+    handleKeyPress = (event) => {
+        const mathQuillKey = this.domKeyToMathQuillKey(event.key);
+
+        if (mathQuillKey){
+            this.mathField.pressKey(mathQuillKey);
+
+            const value = this.mathField.getContent();
+            if (this.props.value !== value) {
+                this.mathField.setContent(this.props.value);
+                this.props.onChange(value, false);
+            }
+        }
+    };      
+
     render() {
         const {focused, handle} = this.state;
         const {style} = this.props;
@@ -753,6 +807,7 @@ class MathInput extends React.Component {
                 ref={node => {
                     this.inputRef = node;
                 }}
+                onKeyUp={this.handleKeyPress}
             >
                 {/* NOTE(charlie): This element must be styled with inline
                     styles rather than with Aphrodite classes, as MathQuill

--- a/src/data/keys.js
+++ b/src/data/keys.js
@@ -7,25 +7,25 @@
 // We should clean it up by removing this file and requiring clients to use the
 // `id` field on the key configurations.
 const Keys = {
-    PLUS: 'PLUS',
+    PLUS: 'PLUS', //
     MINUS: 'MINUS',
-    NEGATIVE: 'NEGATIVE',
-    TIMES: 'TIMES',
-    DIVIDE: 'DIVIDE',
+    NEGATIVE: 'NEGATIVE', //
+    TIMES: 'TIMES', //
+    DIVIDE: 'DIVIDE', //
     DECIMAL: 'DECIMAL',
-    PERIOD: 'PERIOD',
-    PERCENT: 'PERCENT',
+    PERIOD: 'PERIOD', //
+    PERCENT: 'PERCENT', //
     CDOT: 'CDOT',
-    EQUAL: 'EQUAL',
+    EQUAL: 'EQUAL', //
     NEQ: 'NEQ',
-    GT: 'GT',
-    LT: 'LT',
+    GT: 'GT', //
+    LT: 'LT', //
     GEQ: 'GEQ',
     LEQ: 'LEQ',
     FRAC_INCLUSIVE: 'FRAC_INCLUSIVE', // mobile native only
     FRAC_EXCLUSIVE: 'FRAC_EXCLUSIVE', // mobile native only
     FRAC: 'FRAC',
-    EXP: 'EXP',
+    EXP: 'EXP', //
     EXP_2: 'EXP_2',
     EXP_3: 'EXP_3',
     SQRT: 'SQRT',

--- a/src/data/keys.js
+++ b/src/data/keys.js
@@ -7,25 +7,25 @@
 // We should clean it up by removing this file and requiring clients to use the
 // `id` field on the key configurations.
 const Keys = {
-    PLUS: 'PLUS', //
+    PLUS: 'PLUS',
     MINUS: 'MINUS',
-    NEGATIVE: 'NEGATIVE', //
-    TIMES: 'TIMES', //
-    DIVIDE: 'DIVIDE', //
+    NEGATIVE: 'NEGATIVE',
+    TIMES: 'TIMES',
+    DIVIDE: 'DIVIDE',
     DECIMAL: 'DECIMAL',
-    PERIOD: 'PERIOD', //
-    PERCENT: 'PERCENT', //
+    PERIOD: 'PERIOD',
+    PERCENT: 'PERCENT',
     CDOT: 'CDOT',
-    EQUAL: 'EQUAL', //
+    EQUAL: 'EQUAL',
     NEQ: 'NEQ',
-    GT: 'GT', //
-    LT: 'LT', //
+    GT: 'GT',
+    LT: 'LT',
     GEQ: 'GEQ',
     LEQ: 'LEQ',
     FRAC_INCLUSIVE: 'FRAC_INCLUSIVE', // mobile native only
     FRAC_EXCLUSIVE: 'FRAC_EXCLUSIVE', // mobile native only
     FRAC: 'FRAC',
-    EXP: 'EXP', //
+    EXP: 'EXP',
     EXP_2: 'EXP_2',
     EXP_3: 'EXP_3',
     SQRT: 'SQRT',


### PR DESCRIPTION
Adds the ability to use a hardware keyboard with the math input. This allows basic input of numbers, operators, and the delete key.

In the future we could choose to allow multi character input (like != or >=) and complex input (like sin, cos, tan), and more movement keys (like arrows, control+a, control+e). All of these things will greatly increase the complexity in the implementation and might be platform dependent so we want to wait until learners give a clear signal that they want these features.