### PR TITLE
Update colors to use Wonder Blocks colors

### DIFF
--- a/less/overrides.less
+++ b/less/overrides.less
@@ -1,5 +1,5 @@
-@brightGreen: #78C008;
-@gray: #CCC;
+@wonderBlocksBlue: #1865f2;
+@offBlack16: rgba(33, 36, 44, 0.16);
 
 @cursorWidth: 2px;
 @cursorMargin: -1px;
@@ -12,6 +12,8 @@
 @cursorAnimationDuration: 500ms;
 
 .keypad-input {
+    outline: none !important;
+
     .mq-editable-field {
         .mq-cursor:not(:only-child),
         .mq-root-block.mq-hasCursor > .mq-cursor:only-child {
@@ -25,9 +27,7 @@
         }
 
         .mq-cursor {
-            border-color: @brightGreen;
-
-            border-left: @cursorWidth solid @brightGreen !important;
+            border-left: @cursorWidth solid @wonderBlocksBlue !important;
 
             margin-left: @cursorMargin !important;
             margin-right: @cursorMargin !important;
@@ -48,15 +48,15 @@
         .mq-non-leaf .mq-cursor:only-child {
             // Set the cursor to a grey rectangle, rather than a vertical line.
             border: @cursorWidth solid !important;
-            border-color: @brightGreen !important;
+            border-color: @wonderBlocksBlue !important;
             border-radius: @emptyBlockBorderRadius;
             opacity: 1 !important;
             padding: 0 @emptyBlockPadding 0 @emptyBlockPadding;
             transition: border-color @cursorAnimationDuration ease-out !important;
 
             &.mq-blink {
-                // And animate it between bright green and gray.
-                border-color: @gray !important;
+                // And animate it between blue and gray.
+                border-color: @wonderBlocksBlue !important;
                 opacity: 1 !important;
                 transition: border-color @cursorAnimationDuration ease-in !important;
             }
@@ -72,7 +72,7 @@
     // loses focus).
     .mq-empty:not(.mq-root-block):after,
     .mq-hasCursor:empty:not(.mq-root-block):after {
-        border: @cursorWidth solid @gray;
+        border: @cursorWidth solid @offBlack16;
         border-radius: @emptyBlockBorderRadius;
         // Hides the 'c' content added by MathQuill to measure the width.
         color: transparent;
@@ -96,7 +96,7 @@
     .mq-math-mode .mq-selection,
     .mq-editable-field .mq-selection {
         .mq-non-leaf {
-            background: @brightGreen !important;
+            background: @wonderBlocksBlue !important;
             border-color: white !important;
             color: white !important;
         }
@@ -109,7 +109,7 @@
     }
 
     .mq-selection {
-        background: @brightGreen !important;
+        background: @wonderBlocksBlue !important;
         border-color: white !important;
         color: white !important;
         display: inline-block !important;

--- a/src/components/common-style.js
+++ b/src/components/common-style.js
@@ -1,16 +1,17 @@
 /**
  * Common parameters used to style components.
  */
-
-const gray85 = '#D6D8DA';
+const offBlack16 = 'rgba(33, 36, 44, 0.16)';
 
 module.exports = {
-    brightGreen: '#78C008',
-    gray17: '#21242C',
-    gray25: '#3B3E40',
-    gray68: '#888D93',
-    gray76: '#BABEC2',
-    gray85,
+    // TODO(diedra): Import Wonder Blocks and get these values from there.
+    wonderBlocksBlue: '#1865f2',
+    offBlack: '#21242c',
+    offBlack50: 'rgba(33, 36, 44, 0.50)',
+    offBlack32: 'rgba(33, 36, 44, 0.32)',
+    offBlack16,
+    offBlack8: 'rgba(33, 36, 44, 0.8)',
+
     iconSizeHeightPx: 48,
     iconSizeWidthPx: 48,
     compactKeypadBorderRadiusPx: 4,
@@ -29,7 +30,7 @@ module.exports = {
     emptyGrey : '#F0F1F2',
 
     // Constants defining any borders between elements in the keypad.
-    innerBorderColor: gray85,
+    innerBorderColor: offBlack16,
     innerBorderStyle: 'solid',
     innerBorderWidthPx: 1,
 

--- a/src/components/corner-decal.js
+++ b/src/components/corner-decal.js
@@ -7,7 +7,7 @@ const PropTypes = require('prop-types');
 const {StyleSheet} = require('aphrodite');
 
 const {View} = require('../fake-react-native-web');
-const {gray25} = require('./common-style');
+const {offBlack} = require('./common-style');
 
 class CornerDecal extends React.Component {
     static propTypes = {
@@ -29,7 +29,7 @@ class CornerDecal extends React.Component {
                 viewBox="4 4 8 8"
             >
                 <path
-                    fill={gray25}
+                    fill={offBlack}
                     opacity="0.3"
                     d="M5.29289322,5.70710678 L10.2928932,10.7071068 C10.9228581,11.3370716 12,10.8909049 12,10 L12,5 C12,4.44771525 11.5522847,4 11,4 L6,4 C5.10909515,4 4.66292836,5.07714192 5.29289322,5.70710678 Z" // @Nolint
                 />

--- a/src/components/icon.js
+++ b/src/components/icon.js
@@ -11,10 +11,10 @@ const SvgIcon = require('./svg-icon');
 const TextIcon = require('./text-icon');
 const {IconTypes} = require('../consts');
 const {iconPropType} = require('./prop-types');
-const {gray25} = require('./common-style');
+const {offBlack} = require('./common-style');
 
 const focusedColor = '#FFF';
-const unfocusedColor = gray25;
+const unfocusedColor = offBlack;
 
 class Icon extends React.PureComponent {
     static propTypes = {

--- a/src/components/input/cursor-handle.js
+++ b/src/components/input/cursor-handle.js
@@ -7,7 +7,7 @@ const PropTypes = require('prop-types');
 
 const {
     cursorHandleRadiusPx,
-    brightGreen,
+    wonderBlocksBlue,
     cursorHandleDistanceMultiplier,
 } = require('../common-style');
 
@@ -97,7 +97,7 @@ class CursorHandle extends React.Component {
                           ${0.707 * cursorRadiusPx} ${0.707 * cursorRadiusPx}
                         Z`
                     }
-                    fill={brightGreen}
+                    fill={wonderBlocksBlue}
                 />
             </svg>
         </span>;

--- a/src/components/input/math-input.js
+++ b/src/components/input/math-input.js
@@ -11,10 +11,10 @@ const DragListener = require('./drag-listener');
 const {
     cursorHandleRadiusPx,
     cursorHandleDistanceMultiplier,
-    gray76,
+    offBlack50,
  } = require('../common-style');
 const {keypadElementPropType} = require('../prop-types');
-const {brightGreen, gray17} = require('../common-style');
+const {wonderBlocksBlue, offBlack} = require('../common-style');
 const Keys = require("../../data/keys");
 
 const i18n = window.i18n || {_: s => s};
@@ -782,7 +782,7 @@ class MathInput extends React.Component {
             ...inlineStyles.innerContainer,
             borderWidth: borderWidthPx,
             ...padding,
-            ...(focused ? {borderColor: brightGreen} : {}),
+            ...(focused ? {borderColor: wonderBlocksBlue} : {}),
             ...style,
         };
 
@@ -866,9 +866,9 @@ const inlineStyles = {
         position: 'relative',
         overflow: 'hidden',
         borderStyle: 'solid',
-        borderColor: gray76,
+        borderColor: offBlack50,
         borderRadius: 4,
-        color: gray17,
+        color: offBlack,
     },
 };
 

--- a/src/components/keypad-button.js
+++ b/src/components/keypad-button.js
@@ -13,7 +13,7 @@ const MultiSymbolGrid = require('./multi-symbol-grid');
 const CornerDecal = require('./corner-decal');
 const {KeyTypes, BorderDirections, BorderStyles} = require('../consts');
 const {
-    brightGreen,
+    wonderBlocksBlue,
     innerBorderColor,
     innerBorderStyle,
     innerBorderWidthPx,
@@ -296,7 +296,7 @@ const styles = StyleSheet.create({
     },
 
     bright: {
-        backgroundColor: brightGreen,
+        backgroundColor: wonderBlocksBlue,
     },
     light: {
         backgroundColor: 'rgba(33, 36, 44, 0.1)',

--- a/src/components/navigation-pad.js
+++ b/src/components/navigation-pad.js
@@ -13,7 +13,7 @@ const {
     navigationPadWidthPx,
     controlGrey,
     valueGrey,
-    gray85,
+    offBlack16,
 } = require('./common-style');
 const {BorderStyles} = require('../consts');
 const KeyConfigs = require('../data/key-configs');
@@ -80,7 +80,7 @@ const styles = StyleSheet.create({
     },
 
     navigationKey: {
-        borderColor: gray85,
+        borderColor: offBlack16,
         backgroundColor: valueGrey,
         width: buttonSizePx,
         height: buttonSizePx,

--- a/src/components/pager-indicator.js
+++ b/src/components/pager-indicator.js
@@ -8,7 +8,7 @@ const PropTypes = require('prop-types');
 const {StyleSheet} = require('aphrodite');
 
 const {View} = require('../fake-react-native-web');
-const {pageIndicatorHeightPx, gray68, gray85} = require('./common-style');
+const {pageIndicatorHeightPx, offBlack50, offBlack16} = require('./common-style');
 
 class PagerIcon extends React.Component {
     static propTypes = {
@@ -24,7 +24,7 @@ class PagerIcon extends React.Component {
     render() {
         const {active, radiusPx} = this.props;
 
-        const fillColor = active ? gray68 : gray85;
+        const fillColor = active ? offBlack50 : offBlack16;
 
         return <svg width={2 * radiusPx} height={2 * radiusPx}>
             <circle

--- a/src/components/two-page-keypad.js
+++ b/src/components/two-page-keypad.js
@@ -13,7 +13,7 @@ const PagerIndicator = require('./pager-indicator');
 const {View} = require('../fake-react-native-web');
 const {column, reverseRow, fullWidth} = require('./styles');
 const {
-    innerBorderColor, innerBorderStyle, innerBorderWidthPx, gray85,
+    innerBorderColor, innerBorderStyle, innerBorderWidthPx, offBlack16,
 } = require('./common-style');
 
 class TwoPageKeypad extends React.Component {
@@ -65,7 +65,7 @@ const styles = StyleSheet.create({
     keypad: {
         // Set the background to light grey, so that when the user drags the
         // keypad pages past the edges, there's a grey backdrop.
-        backgroundColor: gray85,
+        backgroundColor: offBlack16,
     },
 
     borderTop: {


### PR DESCRIPTION
# SUMMARY
I went back and forth about this one a bit, and I decided to just pick a direction and get your opinion on it.

This commit
  - adds temporary variables with hard-coded Wonder Blocks color values
  - updates *all* the colors in the repo (except for in `cursor-handle.js`, to be handled separately)
  - removes the focus outline (not color-related but it makes it much easier compare the focus state with the design)

The colors that were shown in the designs were of course changed to those colors. All other colors were changed according to this pattern:
  - brightGreen -> wonderBlocksBlue
  - #CCC -> offBlack16
  - gray85 -> offBlack16
  - gray76 -> offBlack50
  - gray68 -> offBlack50
  - gray25 -> offBlack
  - gray17 -> offBlack

I debated whether I should only change the colors that I can see and test, but I feel like that will lead us to updating these colors ad-hoc in the future as we notice them, which means that until we notice them, the old colors will just hang around looking out of place. This way, they're all converted at once in a consistent way so whatever grays were supposed to match in different areas will still match, etc. And we can always change which grays are used where later.

For the grays, I just pulled the different swatches into Photoshop and compared them to find the visually closest Wonder Blocks gray to convert them to.

Thoughts?

Jira: https://khanacademy.atlassian.net/browse/LP-7669
Designs: https://www.figma.com/file/2lUPOSbOP8tbW7RLqbBFLh/Expression-Widget?node-id=542%3A1369

# SCREENSHOTS
## Unfocused view
### BEFORE
![unfocused_b](https://user-images.githubusercontent.com/7761701/73196670-db0ced00-40e4-11ea-825b-cadaf34e2c17.png)

### AFTER
![unfocused](https://user-images.githubusercontent.com/7761701/73196674-dfd1a100-40e4-11ea-8c20-78f061fa66ef.png)

## Focused view
### BEFORE
![focused_b](https://user-images.githubusercontent.com/7761701/73196782-0ee81280-40e5-11ea-950d-f1e82d1e53fc.png)

### AFTER
![focused](https://user-images.githubusercontent.com/7761701/73196788-13143000-40e5-11ea-9837-08fcbf6ed931.png)

## Other keyboard view
### BEFORE
![Screen Shot 2020-01-27 at 9 13 52 AM](https://user-images.githubusercontent.com/7761701/73196980-6c7c5f00-40e5-11ea-85ff-99c47dd67b55.png)

### AFTER
![keyboard](https://user-images.githubusercontent.com/7761701/73196808-1c050180-40e5-11ea-9fa8-e55378764977.png)

## Gif
### BEFORE
![before](https://user-images.githubusercontent.com/7761701/73196816-20c9b580-40e5-11ea-96c2-b0f23d9497fc.gif)

### AFTER
![after](https://user-images.githubusercontent.com/7761701/73196828-245d3c80-40e5-11ea-82dc-29727b003510.gif)

# TEST PLAN
Open the `index.html` file,
open the dev tools and turn on mobile simulation,
verify the unfocused state looks the same except the border color is slightly darker,
tap on the input field,
verify the border becomes blue, the blinking cursor appears and is blue, there's no focus outline, and the keypad buttons (on both keypads) look okay.
Click a buncha buttons on the keypad,
verify the animation colors are blue,
and verify everything works as expected.
Tap into the input field,
verify the cursor handle appears and it's blue,
pull it around,
and verify it works as expected.