### PR TITLE
New cursor handle icon

### DIFF
--- a/less/overrides.less
+++ b/less/overrides.less
@@ -22,6 +22,7 @@
                with the exception that it's also visible when the entire input is
                empty. */
             height: 20px !important;
+            width: @cursorWidth;
             margin-top: -5px !important;
             vertical-align: middle !important;
             border-radius: 1px !important;

--- a/less/overrides.less
+++ b/less/overrides.less
@@ -24,6 +24,7 @@
             height: 20px !important;
             margin-top: -5px !important;
             vertical-align: middle !important;
+            border-radius: 1px !important;
         }
 
         .mq-cursor {

--- a/src/components/common-style.js
+++ b/src/components/common-style.js
@@ -20,8 +20,8 @@ module.exports = {
     // The amount to multiply the radius by to get the distance from the
     // center to the tip of the cursor handle.  The cursor is a circle with
     // one quadrant replace with a square.  The hypotenuse of the square is
-    // 1.41 times the radius of the circle.
-    cursorHandleDistanceMultiplier: 1.41,
+    // 1.045 times the radius of the circle.
+    cursorHandleDistanceMultiplier: 1.045,
 
     // Keypad button colors
     valueGrey: '#FFF',

--- a/src/components/expression-keypad.js
+++ b/src/components/expression-keypad.js
@@ -18,10 +18,6 @@ const {
     fullWidth,
     roundedTopLeft,
     roundedTopRight,
-    reverseColumn,
-    keyLeft,
-    keyCenter,
-    keyRight,
 } = require('./styles');
 const {BorderStyles} = require('../consts');
 const {valueGrey, controlGrey} = require('./common-style');
@@ -95,231 +91,198 @@ class ExpressionKeypad extends React.Component {
             dismissOrJumpOutKey = KeyConfigs.DISMISS;
         }
 
-        // list all the buttons in logical tab order
-
         const rightPageStyle = [
             row,
             fullWidth,
             styles.rightPage,
             roundTopRight && roundedTopRight,
         ];
-        const rightPage = (
-            <View style={rightPageStyle}>
-                <View style={column}>
-                    <View style={reverseColumn}>
-                        <View style={row}>
-                            <TouchableKeypadButton
-                                keyConfig={KeyConfigs.NUM_1}
-                                borders={BorderStyles.BOTTOM}
-                            />
-                            <TouchableKeypadButton
-                                keyConfig={KeyConfigs.NUM_2}
-                                borders={BorderStyles.NONE}
-                            />
-                            <TouchableKeypadButton
-                                keyConfig={KeyConfigs.NUM_3}
-                                borders={BorderStyles.BOTTOM}
-                            />
-                        </View>
-                        <View style={row}>
-                            <TouchableKeypadButton
-                                keyConfig={KeyConfigs.NUM_4}
-                                borders={BorderStyles.NONE}
-                            />
-                            <TouchableKeypadButton
-                                keyConfig={KeyConfigs.NUM_5}
-                                borders={BorderStyles.NONE}
-                            />
-                            <TouchableKeypadButton
-                                keyConfig={KeyConfigs.NUM_6}
-                                borders={BorderStyles.NONE}
-                            />
-                        </View>
-                        <View style={row}>
-                            <TouchableKeypadButton
-                                keyConfig={KeyConfigs.NUM_7}
-                                borders={BorderStyles.NONE}
-                            />
-                            <TouchableKeypadButton
-                                keyConfig={KeyConfigs.NUM_8}
-                                borders={BorderStyles.NONE}
-                            />
-                            <TouchableKeypadButton
-                                keyConfig={KeyConfigs.NUM_9}
-                                borders={BorderStyles.NONE}
-                            />
-                        </View>
-                    </View>
-                    <View style={row}>
-                        <TouchableKeypadButton
-                            keyConfig={KeyConfigs.NUM_0}
-                            borders={BorderStyles.LEFT}
-                            style={keyCenter}
-                        />
-                        <TouchableKeypadButton
-                            keyConfig={KeyConfigs.DECIMAL}
-                            borders={BorderStyles.LEFT}
-                            style={keyRight}
-                        />
-                        <ManyKeypadButton
-                            keys={extraKeys}
-                            borders={BorderStyles.NONE}
-                            style={keyLeft}
-                        />
-                    </View>
-                </View>
-                <View style={[reverseColumn, oneColumn]}>
-                    <TouchableKeypadButton
-                        keyConfig={KeyConfigs.PLUS}
-                        borders={BorderStyles.LEFT}
-                    />
-                    <TouchableKeypadButton
-                        keyConfig={KeyConfigs.MINUS}
-                        borders={BorderStyles.LEFT}
-                    />
-                    <TouchableKeypadButton
-                        keyConfig={KeyConfigs.TIMES}
-                        borders={BorderStyles.LEFT}
-                    />
-                    <TouchableKeypadButton
-                        keyConfig={KeyConfigs.DIVIDE}
-                        borders={BorderStyles.LEFT}
-                    />
-                </View>
-                <View style={[column, oneColumn]}>
-                    <View style={[column, oneColumn]}>
-                        <TouchableKeypadButton
-                            keyConfig={KeyConfigs.FRAC}
-                            style={roundTopRight && roundedTopRight}
-                        />
-                        <TouchableKeypadButton keyConfig={KeyConfigs.CDOT} />
-                    </View>
-                    <View style={[column, oneColumn]}>
-                        <TouchableKeypadButton
-                            keyConfig={KeyConfigs.BACKSPACE}
-                            borders={BorderStyles.LEFT}
-                        />
-                        <TouchableKeypadButton
-                            keyConfig={dismissOrJumpOutKey}
-                            borders={BorderStyles.LEFT}
-                        />
-                    </View>
-                </View>
+        const rightPage = <View style={rightPageStyle}>
+            <View style={[column, oneColumn]}>
+                <TouchableKeypadButton
+                    keyConfig={KeyConfigs.NUM_7}
+                    borders={BorderStyles.NONE}
+                />
+                <TouchableKeypadButton
+                    keyConfig={KeyConfigs.NUM_4}
+                    borders={BorderStyles.NONE}
+                />
+                <TouchableKeypadButton
+                    keyConfig={KeyConfigs.NUM_1}
+                    borders={BorderStyles.BOTTOM}
+                />
+                <ManyKeypadButton
+                    keys={extraKeys}
+                    borders={BorderStyles.NONE}
+                />
             </View>
-        );
+            <View style={[column, oneColumn]}>
+                <TouchableKeypadButton
+                    keyConfig={KeyConfigs.NUM_8}
+                    borders={BorderStyles.NONE}
+                />
+                <TouchableKeypadButton
+                    keyConfig={KeyConfigs.NUM_5}
+                    borders={BorderStyles.NONE}
+                />
+                <TouchableKeypadButton
+                    keyConfig={KeyConfigs.NUM_2}
+                    borders={BorderStyles.NONE}
+                />
+                <TouchableKeypadButton
+                    keyConfig={KeyConfigs.NUM_0}
+                    borders={BorderStyles.LEFT}
+                />
+            </View>
+            <View style={[column, oneColumn]}>
+                <TouchableKeypadButton
+                    keyConfig={KeyConfigs.NUM_9}
+                    borders={BorderStyles.NONE}
+                />
+                <TouchableKeypadButton
+                    keyConfig={KeyConfigs.NUM_6}
+                    borders={BorderStyles.NONE}
+                />
+                <TouchableKeypadButton
+                    keyConfig={KeyConfigs.NUM_3}
+                    borders={BorderStyles.BOTTOM}
+                />
+                <TouchableKeypadButton
+                    keyConfig={KeyConfigs.DECIMAL}
+                    borders={BorderStyles.LEFT}
+                />
+            </View>
+            <View style={[column, oneColumn]}>
+                <TouchableKeypadButton
+                    keyConfig={KeyConfigs.DIVIDE}
+                    borders={BorderStyles.LEFT}
+                />
+                <TouchableKeypadButton
+                    keyConfig={KeyConfigs.TIMES}
+                    borders={BorderStyles.LEFT}
+                />
+                <TouchableKeypadButton
+                    keyConfig={KeyConfigs.MINUS}
+                    borders={BorderStyles.LEFT}
+                />
+                <TouchableKeypadButton
+                    keyConfig={KeyConfigs.PLUS}
+                    borders={BorderStyles.LEFT}
+                />
+            </View>
+            <View style={[column, oneColumn]}>
+                <TouchableKeypadButton
+                    keyConfig={KeyConfigs.FRAC}
+                    style={roundTopRight && roundedTopRight}
+                />
+                <TouchableKeypadButton keyConfig={KeyConfigs.CDOT} />
+                <TouchableKeypadButton
+                    keyConfig={KeyConfigs.BACKSPACE}
+                    borders={BorderStyles.LEFT}
+                />
+                <TouchableKeypadButton
+                    keyConfig={dismissOrJumpOutKey}
+                    borders={BorderStyles.LEFT}
+                />
+            </View>
+        </View>;
 
         const leftPageStyle = [
-            column,
+            row,
             fullWidth,
             styles.leftPage,
             roundTopLeft && roundedTopLeft,
         ];
-        const leftPage = (
-            <View style={leftPageStyle}>
-                <View style={row}>
-                    <View style={column}>
-                        <View style={row}>
-                            <TouchableKeypadButton
-                                keyConfig={KeyConfigs.EXP_2}
-                                borders={BorderStyles.NONE}
-                                style={roundTopLeft && roundedTopLeft}
-                            />
-                            <TouchableKeypadButton
-                                keyConfig={KeyConfigs.EXP_3}
-                                borders={BorderStyles.NONE}
-                            />
-                            <TouchableKeypadButton
-                                keyConfig={KeyConfigs.EXP}
-                                borders={BorderStyles.NONE}
-                            />
-                        </View>
-                        <View style={row}>
-                            <TouchableKeypadButton
-                                keyConfig={KeyConfigs.SQRT}
-                                borders={BorderStyles.NONE}
-                            />
-                            <TouchableKeypadButton
-                                keyConfig={KeyConfigs.CUBE_ROOT}
-                                borders={BorderStyles.NONE}
-                            />
-                            <TouchableKeypadButton
-                                keyConfig={KeyConfigs.RADICAL}
-                                borders={BorderStyles.NONE}
-                            />
-                        </View>
-                        <View style={row}>
-                            <TouchableKeypadButton
-                                keyConfig={KeyConfigs.LOG}
-                                borders={BorderStyles.BOTTOM}
-                            />
-                            <TouchableKeypadButton
-                                keyConfig={KeyConfigs.LN}
-                                borders={BorderStyles.BOTTOM}
-                            />
-                            <TouchableKeypadButton
-                                keyConfig={KeyConfigs.LOG_N}
-                                borders={BorderStyles.BOTTOM}
-                            />
-                        </View>
-                    </View>
-                    <View style={column}>
-                        <View style={row}>
-                            <TouchableKeypadButton
-                                keyConfig={KeyConfigs.GEQ}
-                                borders={BorderStyles.LEFT}
-                            />
-                            <TouchableKeypadButton
-                                keyConfig={KeyConfigs.GT}
-                                borders={BorderStyles.NONE}
-                            />
-                        </View>
-                        <View style={row}>
-                            <TouchableKeypadButton
-                                keyConfig={KeyConfigs.EQUAL}
-                                borders={BorderStyles.LEFT}
-                            />
-                            <TouchableKeypadButton
-                                keyConfig={KeyConfigs.NEQ}
-                                borders={BorderStyles.NONE}
-                            />
-                        </View>
-                        <View style={row}>
-                            <TouchableKeypadButton keyConfig={KeyConfigs.LEQ} />
-                            <TouchableKeypadButton
-                                keyConfig={KeyConfigs.LT}
-                                borders={BorderStyles.BOTTOM}
-                            />
-                        </View>
-                    </View>
-                </View>
-                <View style={row}>
-                    <View style={row}>
-                        <TouchableKeypadButton
-                            keyConfig={KeyConfigs.SIN}
-                            borders={BorderStyles.NONE}
-                        />
-                        <TouchableKeypadButton
-                            keyConfig={KeyConfigs.COS}
-                            borders={BorderStyles.NONE}
-                        />
-                        <TouchableKeypadButton
-                            keyConfig={KeyConfigs.TAN}
-                            borders={BorderStyles.NONE}
-                        />
-                    </View>
-                    <View style={row}>
-                        <TouchableKeypadButton
-                            keyConfig={KeyConfigs.LEFT_PAREN}
-                            borders={BorderStyles.LEFT}
-                        />
-                        <TouchableKeypadButton
-                            keyConfig={KeyConfigs.RIGHT_PAREN}
-                            borders={BorderStyles.NONE}
-                        />
-                    </View>
-                </View>
+        const leftPage = <View style={leftPageStyle}>
+            <View style={[column, oneColumn]}>
+                <TouchableKeypadButton
+                    keyConfig={KeyConfigs.EXP_2}
+                    borders={BorderStyles.NONE}
+                    style={roundTopLeft && roundedTopLeft}
+                />
+                <TouchableKeypadButton
+                    keyConfig={KeyConfigs.SQRT}
+                    borders={BorderStyles.NONE}
+                />
+                <TouchableKeypadButton
+                    keyConfig={KeyConfigs.LOG}
+                    borders={BorderStyles.BOTTOM}
+                />
+                <TouchableKeypadButton
+                    keyConfig={KeyConfigs.SIN}
+                    borders={BorderStyles.NONE}
+                />
             </View>
-        );
+            <View style={[column, oneColumn]}>
+                <TouchableKeypadButton
+                    keyConfig={KeyConfigs.EXP_3}
+                    borders={BorderStyles.NONE}
+                />
+                <TouchableKeypadButton
+                    keyConfig={KeyConfigs.CUBE_ROOT}
+                    borders={BorderStyles.NONE}
+                />
+                <TouchableKeypadButton
+                    keyConfig={KeyConfigs.LN}
+                    borders={BorderStyles.BOTTOM}
+                />
+                <TouchableKeypadButton
+                    keyConfig={KeyConfigs.COS}
+                    borders={BorderStyles.NONE}
+                />
+            </View>
+            <View style={[column, oneColumn]}>
+                <TouchableKeypadButton
+                    keyConfig={KeyConfigs.EXP}
+                    borders={BorderStyles.NONE}
+                />
+                <TouchableKeypadButton
+                    keyConfig={KeyConfigs.RADICAL}
+                    borders={BorderStyles.NONE}
+                />
+                <TouchableKeypadButton
+                    keyConfig={KeyConfigs.LOG_N}
+                    borders={BorderStyles.BOTTOM}
+                />
+                <TouchableKeypadButton
+                    keyConfig={KeyConfigs.TAN}
+                    borders={BorderStyles.NONE}
+                />
+            </View>
+            <View style={[column, oneColumn]}>
+                <TouchableKeypadButton
+                    keyConfig={KeyConfigs.GEQ}
+                    borders={BorderStyles.LEFT}
+                />
+                <TouchableKeypadButton
+                    keyConfig={KeyConfigs.EQUAL}
+                    borders={BorderStyles.LEFT}
+                />
+                <TouchableKeypadButton keyConfig={KeyConfigs.LEQ} />
+                <TouchableKeypadButton
+                    keyConfig={KeyConfigs.LEFT_PAREN}
+                    borders={BorderStyles.LEFT}
+                />
+            </View>
+            <View style={[column, oneColumn]}>
+                <TouchableKeypadButton
+                    keyConfig={KeyConfigs.GT}
+                    borders={BorderStyles.NONE}
+                />
+                <TouchableKeypadButton
+                    keyConfig={KeyConfigs.NEQ}
+                    borders={BorderStyles.NONE}
+                />
+                <TouchableKeypadButton
+                    keyConfig={KeyConfigs.LT}
+                    borders={BorderStyles.BOTTOM}
+                />
+                <TouchableKeypadButton
+                    keyConfig={KeyConfigs.RIGHT_PAREN}
+                    borders={BorderStyles.NONE}
+                />
+            </View>
+        </View>;
 
         return <TwoPageKeypad
             currentPage={currentPage}

--- a/src/components/fraction-keypad.js
+++ b/src/components/fraction-keypad.js
@@ -10,17 +10,7 @@ const {connect} = require('react-redux');
 const {View} = require('../fake-react-native-web');
 const Keypad = require('./keypad');
 const TouchableKeypadButton = require('./touchable-keypad-button');
-const {
-    row,
-    column,
-    oneColumn,
-    reverseColumn,
-    roundedTopLeft,
-    roundedTopRight,
-    keyLeft,
-    keyCenter,
-    keyRight
-} = require('./styles');
+const {row, roundedTopLeft, roundedTopRight} = require('./styles');
 const {BorderStyles} = require('../consts');
 const CursorContexts = require('./input/cursor-contexts');
 const {cursorContextPropType} = require('./prop-types');
@@ -88,109 +78,88 @@ class FractionKeypad extends React.Component {
             dismissOrJumpOutKey = KeyConfigs.DISMISS;
         }
 
-        return (
-            <Keypad>
-                <View style={row}>
-                    <View style={column}>
-                        <View style={reverseColumn}>
-                            <View style={row}>
-                                <TouchableKeypadButton
-                                    keyConfig={KeyConfigs.NUM_1}
-                                    borders={BorderStyles.BOTTOM}
-                                />
-                                <TouchableKeypadButton
-                                    keyConfig={KeyConfigs.NUM_2}
-                                    borders={BorderStyles.NONE}
-                                />
-                                <TouchableKeypadButton
-                                    keyConfig={KeyConfigs.NUM_3}
-                                    borders={BorderStyles.BOTTOM}
-                                />
-                            </View>
-                            <View style={row}>
-                                <TouchableKeypadButton
-                                    keyConfig={KeyConfigs.NUM_4}
-                                    borders={BorderStyles.NONE}
-                                />
-                                <TouchableKeypadButton
-                                    keyConfig={KeyConfigs.NUM_5}
-                                    borders={BorderStyles.NONE}
-                                />
-                                <TouchableKeypadButton
-                                    keyConfig={KeyConfigs.NUM_6}
-                                    borders={BorderStyles.NONE}
-                                />
-                            </View>
-                            <View style={row}>
-                                <TouchableKeypadButton
-                                    keyConfig={KeyConfigs.NUM_7}
-                                    borders={BorderStyles.NONE}
-                                    style={roundTopLeft && roundedTopLeft}
-                                />
-                                <TouchableKeypadButton
-                                    keyConfig={KeyConfigs.NUM_8}
-                                    borders={BorderStyles.NONE}
-                                />
-                                <TouchableKeypadButton
-                                    keyConfig={KeyConfigs.NUM_9}
-                                    borders={BorderStyles.NONE}
-                                />
-                            </View>
-                        </View>
-                        <View style={row}>
-                            <TouchableKeypadButton
-                                keyConfig={KeyConfigs.NUM_0}
-                                borders={BorderStyles.LEFT}
-                                style={keyCenter}
-                            />
-                            <TouchableKeypadButton
-                                keyConfig={KeyConfigs.DECIMAL}
-                                borders={BorderStyles.LEFT}
-                                style={keyRight}
-                            />
-                            <TouchableKeypadButton
-                                keyConfig={KeyConfigs.NEGATIVE}
-                                borders={BorderStyles.NONE}
-                                style={keyLeft}
-                            />
-                        </View>
-                    </View>
-                    <View style={[column, oneColumn]}>
-                        <View style={[column, oneColumn]}>
-                            <TouchableKeypadButton
-                                keyConfig={KeyConfigs.FRAC}
-                                disabled={
-                                    // NOTE(charlie): It's only sufficient to use
-                                    // `IN_NUMERATOR` and `IN_DENOMINATOR` here because we
-                                    // don't support parentheses in this keypad. If we did,
-                                    // then when the cursor was inside a parenthetical
-                                    // expression in a numerator or denominator, this check
-                                    // would fail.
-                                    cursorContext ===
-                                        CursorContexts.IN_NUMERATOR ||
-                                    cursorContext ===
-                                        CursorContexts.IN_DENOMINATOR
-                                }
-                                style={roundTopRight && roundedTopRight}
-                            />
-                            <TouchableKeypadButton
-                                keyConfig={KeyConfigs.PERCENT}
-                            />
-                        </View>
-                        <View style={[column, oneColumn]}>
-                            <TouchableKeypadButton
-                                keyConfig={KeyConfigs.BACKSPACE}
-                                borders={BorderStyles.LEFT}
-                            />
-                            <TouchableKeypadButton
-                                keyConfig={dismissOrJumpOutKey}
-                                borders={BorderStyles.LEFT}
-                            />
-                        </View>
-                    </View>
-                </View>
-            </Keypad>
-        );
+        return <Keypad>
+            <View style={row}>
+                <TouchableKeypadButton
+                    keyConfig={KeyConfigs.NUM_7}
+                    borders={BorderStyles.NONE}
+                    style={roundTopLeft && roundedTopLeft}
+                />
+                <TouchableKeypadButton
+                    keyConfig={KeyConfigs.NUM_8}
+                    borders={BorderStyles.NONE}
+                />
+                <TouchableKeypadButton
+                    keyConfig={KeyConfigs.NUM_9}
+                    borders={BorderStyles.NONE}
+                />
+                <TouchableKeypadButton
+                    keyConfig={KeyConfigs.FRAC}
+                    disabled={
+                        // NOTE(charlie): It's only sufficient to use
+                        // `IN_NUMERATOR` and `IN_DENOMINATOR` here because we
+                        // don't support parentheses in this keypad. If we did,
+                        // then when the cursor was inside a parenthetical
+                        // expression in a numerator or denominator, this check
+                        // would fail.
+                        cursorContext === CursorContexts.IN_NUMERATOR ||
+                        cursorContext === CursorContexts.IN_DENOMINATOR
+                    }
+                    style={roundTopRight && roundedTopRight}
+                />
+            </View>
+            <View style={row}>
+                <TouchableKeypadButton
+                    keyConfig={KeyConfigs.NUM_4}
+                    borders={BorderStyles.NONE}
+                />
+                <TouchableKeypadButton
+                    keyConfig={KeyConfigs.NUM_5}
+                    borders={BorderStyles.NONE}
+                />
+                <TouchableKeypadButton
+                    keyConfig={KeyConfigs.NUM_6}
+                    borders={BorderStyles.NONE}
+                />
+                <TouchableKeypadButton keyConfig={KeyConfigs.PERCENT} />
+            </View>
+            <View style={row}>
+                <TouchableKeypadButton
+                    keyConfig={KeyConfigs.NUM_1}
+                    borders={BorderStyles.BOTTOM}
+                />
+                <TouchableKeypadButton
+                    keyConfig={KeyConfigs.NUM_2}
+                    borders={BorderStyles.NONE}
+                />
+                <TouchableKeypadButton
+                    keyConfig={KeyConfigs.NUM_3}
+                    borders={BorderStyles.BOTTOM}
+                />
+                <TouchableKeypadButton
+                    keyConfig={KeyConfigs.BACKSPACE}
+                    borders={BorderStyles.LEFT}
+                />
+            </View>
+            <View style={row}>
+                <TouchableKeypadButton
+                    keyConfig={KeyConfigs.NEGATIVE}
+                    borders={BorderStyles.NONE}
+                />
+                <TouchableKeypadButton
+                    keyConfig={KeyConfigs.NUM_0}
+                    borders={BorderStyles.LEFT}
+                />
+                <TouchableKeypadButton
+                    keyConfig={KeyConfigs.DECIMAL}
+                    borders={BorderStyles.LEFT}
+                />
+                <TouchableKeypadButton
+                    keyConfig={dismissOrJumpOutKey}
+                    borders={BorderStyles.LEFT}
+                />
+            </View>
+        </Keypad>;
     }
 }
 

--- a/src/components/input/cursor-handle.js
+++ b/src/components/input/cursor-handle.js
@@ -7,18 +7,17 @@ const PropTypes = require('prop-types');
 
 const {
     cursorHandleRadiusPx,
-    wonderBlocksBlue,
     cursorHandleDistanceMultiplier,
+    wonderBlocksBlue,
 } = require('../common-style');
 
-const touchTargetRadiusPx = 22;
+const touchTargetRadiusPx = 2 * cursorHandleRadiusPx;
 const touchTargetHeightPx = 2 * touchTargetRadiusPx;
 const touchTargetWidthPx = 2 * touchTargetRadiusPx;
 
 const cursorRadiusPx = cursorHandleRadiusPx;
-const cursorHeightPx = cursorHandleDistanceMultiplier * cursorRadiusPx +
-    cursorRadiusPx;
-const cursorWidthPx = 2 * cursorRadiusPx;
+const cursorHeightPx = cursorHandleDistanceMultiplier * (cursorRadiusPx * 4)
+const cursorWidthPx = 4 * cursorRadiusPx;
 
 class CursorHandle extends React.Component {
     static propTypes = {
@@ -70,10 +69,6 @@ class CursorHandle extends React.Component {
             ...animationStyle,
         };
 
-        const innerStyle = {
-            marginLeft: touchTargetRadiusPx - cursorRadiusPx,
-        };
-
         return <span
             style={outerStyle}
             onTouchStart={this.props.onTouchStart}
@@ -82,22 +77,52 @@ class CursorHandle extends React.Component {
             onTouchCancel={this.props.onTouchCancel}
         >
             <svg
+                fill="none"
                 width={cursorWidthPx}
                 height={cursorHeightPx}
-                viewBox={
-                    `-${cursorRadiusPx} 0 ${cursorWidthPx} ${cursorHeightPx}`
-                }
-                style={innerStyle}
+                viewBox={`0 0 ${cursorWidthPx} ${cursorHeightPx}`}
             >
+                <filter
+                    id="a"
+                    colorInterpolationFilters="sRGB"
+                    filterUnits="userSpaceOnUse"
+                    height={cursorHeightPx * 0.87}  // ~40
+                    width={cursorWidthPx * 0.82}  // ~36
+                    x="4"
+                    y="0"
+                >
+                    <feFlood
+                        floodOpacity="0"
+                        result="BackgroundImageFix"
+                    />
+                    <feColorMatrix
+                        in="SourceAlpha"
+                        type="matrix"
+                        values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+                    />
+                    <feOffset dy="4"/>
+                    <feGaussianBlur stdDeviation="4"/>
+                    <feColorMatrix
+                        type="matrix"
+                        values="0 0 0 0 0.129412 0 0 0 0 0.141176 0 0 0 0 0.172549 0 0 0 0.08 0"
+                    />
+                    <feBlend
+                        in2="BackgroundImageFix"
+                        mode="normal"
+                        result="effect1_dropShadow"
+                    />
+                    <feBlend
+                        in="SourceGraphic"
+                        in2="effect1_dropShadow"
+                        mode="normal"
+                        result="shape"
+                    />
+                </filter>
+                <g filter="url(#a)">
                 <path
-                    d={
-                        `M 0 0
-                        L -${0.707 * cursorRadiusPx} ${0.707 * cursorRadiusPx}
-                        A ${cursorRadiusPx} ${cursorRadiusPx}, 0, 1, 0,
-                          ${0.707 * cursorRadiusPx} ${0.707 * cursorRadiusPx}
-                        Z`
-                    }
-                    fill={wonderBlocksBlue}
+                    d="m22 4-7.07 7.0284c-1.3988 1.3901-2.3515 3.1615-2.7376 5.09-.3861 1.9284-.1883 3.9274.5685 5.7441s2.0385 3.3694 3.6831 4.4619c1.6445 1.0925 3.5781 1.6756 5.556 1.6756s3.9115-.5831 5.556-1.6756c1.6446-1.0925 2.9263-2.6452 3.6831-4.4619s.9546-3.8157.5685-5.7441c-.3861-1.9285-1.3388-3.6999-2.7376-5.09z" fill="#1865f2"/></g><path d="m14.9301 10.4841 7.0699-7.06989 7.0699 7.06989.0001.0001c1.3988 1.3984 2.3515 3.1802 2.7376 5.1201s.1883 3.9507-.5685 5.7782c-.7568 1.8274-2.0385 3.3894-3.6831 4.4883-1.6445 1.099-3.5781 1.6855-5.556 1.6855s-3.9115-.5865-5.556-1.6855c-1.6446-1.0989-2.9263-2.6609-3.6831-4.4883-.7568-1.8275-.9546-3.8383-.5685-5.7782s1.3388-3.7217 2.7376-5.1201z"
+                    stroke="#fff"
+                    strokeWidth="2"
                 />
             </svg>
         </span>;

--- a/src/components/keypad-container.js
+++ b/src/components/keypad-container.js
@@ -11,7 +11,7 @@ const zIndexes = require('./z-indexes');
 const {setPageSize} = require('../actions');
 const {keyIdPropType} = require('./prop-types');
 const {KeypadTypes, LayoutModes} = require('../consts');
-const {row, reverseRow, centered, fullWidth} = require('./styles');
+const {row, centered, fullWidth} = require('./styles');
 const {
     innerBorderColor,
     innerBorderStyle,
@@ -166,7 +166,7 @@ class KeypadContainer extends React.Component {
         ];
 
         const keypadStyle = [
-            reverseRow,
+            row,
             styles.keypadBorder,
             layoutMode === LayoutModes.FULLSCREEN ? styles.fullscreen
                                                   : styles.compact,
@@ -181,8 +181,6 @@ class KeypadContainer extends React.Component {
             extraClassName="keypad-container"
         >
             <View
-                // List in logical tab order for a11y and
-                // correct visual order with styling
                 style={keypadStyle}
                 ref={element => {
                     if (!this.hasMounted && element) {
@@ -191,15 +189,15 @@ class KeypadContainer extends React.Component {
                     }
                 }}
             >
-                <View style={styles.keypadLayout}>
-                    {this.renderKeypad()}
-                </View>
-                {active && navigationPadEnabled &&
+                {navigationPadEnabled &&
                     <NavigationPad
                         roundTopLeft={layoutMode === LayoutModes.COMPACT}
                         style={styles.navigationPadContainer}
                     />
                 }
+                <View style={styles.keypadLayout}>
+                    {this.renderKeypad()}
+                </View>
             </View>
         </View>;
     }

--- a/src/components/keypad.js
+++ b/src/components/keypad.js
@@ -83,7 +83,6 @@ class Keypad extends React.Component {
 
     render() {
         const {
-            active,
             children,
             echoes,
             removeEcho,
@@ -122,10 +121,7 @@ class Keypad extends React.Component {
         };
 
         return <View style={style}>
-            {/* a11y: Only render the children after keyboard has been
-            activated. Buttons should only be added to the DOM and be able to
-            receive focus if the keyboard is already active. */}
-            {active && children}
+            {children}
             <EchoManager
                 echoes={relativeEchoes}
                 onAnimationFinish={removeEcho}

--- a/src/components/styles.js
+++ b/src/components/styles.js
@@ -35,23 +35,4 @@ module.exports = StyleSheet.create({
     roundedTopRight: {
         borderTopRightRadius: compactKeypadBorderRadiusPx,
     },
-    reverseRow: {
-        flexDirection: 'row-reverse',
-    },
-    reverseColumn: {
-        flexDirection: 'column-reverse',
-    },
-
-    // Styles for manually placing the keys in visual order even if
-    // they're not in the same logical DOM order.
-    // Specifically for a 3-column keypad.
-    keyLeft: {
-        order: 1,
-    },
-    keyCenter: {
-        order: 2,
-    },
-    keyRight: {
-        order: 3,
-    }
 });

--- a/src/components/two-page-keypad.js
+++ b/src/components/two-page-keypad.js
@@ -11,7 +11,7 @@ const Keypad = require('./keypad');
 const ViewPager = require('./view-pager');
 const PagerIndicator = require('./pager-indicator');
 const {View} = require('../fake-react-native-web');
-const {column, reverseRow, fullWidth} = require('./styles');
+const {column, row, fullWidth} = require('./styles');
 const {
     innerBorderColor, innerBorderStyle, innerBorderWidthPx, offBlack16,
 } = require('./common-style');
@@ -44,16 +44,12 @@ class TwoPageKeypad extends React.Component {
             </Keypad>;
         } else {
             return <Keypad style={styles.keypad}>
-                {/* a11y: Put the right page before the left page in
-                the DOM so that the numbers (right page) receive focus
-                before the additional math keys (left page) in the tab
-                order. */}
-                <View style={reverseRow}>
-                    <View style={[styles.borderLeft, fullWidth]}>
-                        {rightPage}
-                    </View>
+                <View style={row}>
                     <View style={fullWidth}>
                         {leftPage}
+                    </View>
+                    <View style={[styles.borderLeft, fullWidth]}>
+                        {rightPage}
                     </View>
                 </View>
             </Keypad>;

--- a/src/components/view-pager.js
+++ b/src/components/view-pager.js
@@ -11,7 +11,7 @@ const {connect} = require('react-redux');
 const {StyleSheet} = require('aphrodite');
 
 const {View} = require('../fake-react-native-web');
-const {reverseRow} = require('./styles');
+const {row} = require('./styles');
 const {childrenPropType} = require('./prop-types');
 const {
     innerBorderColor,
@@ -55,7 +55,7 @@ class ViewPager extends React.Component {
         const {children, pageWidthPx, translateX} = this.props;
         const {animationDurationMs} = this.state;
 
-        const pagerStyle = [reverseRow, styles.twoPagePager];
+        const pagerStyle = [row, styles.twoPagePager];
 
         const transform = {
             msTransform: `translate3d(${translateX}px, 0, 0)`,
@@ -83,12 +83,11 @@ class ViewPager extends React.Component {
         };
 
         return <View style={pagerStyle} dynamicStyle={dynamicPagerStyle}>
-            {/* list the number keypad page first for tab order */}
             <View dynamicStyle={dynamicPageStyle}>
-                {children[1]}
+                {children[0]}
             </View>
             <View style={styles.rightPage} dynamicStyle={dynamicPageStyle}>
-                {children[0]}
+                {children[1]}
             </View>
         </View>;
     }

--- a/src/fake-react-native-web/view.js
+++ b/src/fake-react-native-web/view.js
@@ -28,7 +28,6 @@ class View extends React.Component {
         onTouchStart: PropTypes.func,
         role: PropTypes.string,
         style: PropTypes.any,
-        tabIndex: PropTypes.number,
     };
 
     static styles = StyleSheet.create({
@@ -76,7 +75,6 @@ class View extends React.Component {
             onTouchStart={this.props.onTouchStart}
             aria-label={this.props.ariaLabel}
             role={this.props.role}
-            tabIndex={this.props.tabIndex}
         >
             {this.props.children}
         </div>;


### PR DESCRIPTION
# SUMMARY
We want to update the cursor handle (the teardrop icon) to be a little more modern looking with a white outline and a subtle drop shadow. This commit mostly just replaces the svg code in `cursor-handle.js` with the new svg code, but there are also some size variables and styling that I had to update because the size is just a little different now.

One unintended side effect I noticed when testing is that when you pull the cursor above and in the horizontal center of the input field, it now snaps to one side of the input values, not in the center of the input values. So that's a little buggy now. I'm not sure how important that is - if that's a blocking change, I'll dig in and figure out where that's coming from.

I also snuck in another change to the blinker cursor so it's now rounded instead of rectangular.

Jira: https://khanacademy.atlassian.net/browse/LP-7670
Design: https://www.figma.com/file/2lUPOSbOP8tbW7RLqbBFLh/Expression-Widget?node-id=542%3A1369

# SCREENSHOTS
## Cursor blinker, no handle
### BEFORE
<img width="643" alt="cursor_before" src="https://user-images.githubusercontent.com/7761701/73204266-845adf80-40f3-11ea-9739-81c3dbfe37db.png">

### AFTER
<img width="636" alt="Screen Shot 2020-01-27 at 10 50 50 AM" src="https://user-images.githubusercontent.com/7761701/73204284-8cb31a80-40f3-11ea-9678-00af56da5b42.png">

## Cursor blinker and handle
### BEFORE
<img width="637" alt="handle_before" src="https://user-images.githubusercontent.com/7761701/73204364-ad7b7000-40f3-11ea-88fc-1e7c3d5199e2.png">

### AFTER
<img width="633" alt="Screen Shot 2020-01-27 at 10 51 15 AM" src="https://user-images.githubusercontent.com/7761701/73204382-b1a78d80-40f3-11ea-92ae-ba21a17deaf1.png">

## Gif of pulling the handle around
### BEFORE
![before](https://user-images.githubusercontent.com/7761701/73204394-b4a27e00-40f3-11ea-86ca-48cdc61e3ca9.gif)

### AFTER
![after](https://user-images.githubusercontent.com/7761701/73204398-b9673200-40f3-11ea-9c1f-5f1e29396680.gif)

# TEST PLAN
Open the index.html file,
open the dev tools and turn on mobile simulation,
verify the unfocused state looks the same,
tap on the input field,
verify the blinking cursor appears and is now rounded.
Click a buncha buttons on the keypad,
tap into the input field,
verify the cursor handle appears and it looks the same but now has a white outline and a slight drop shadow,
pull it around,
and verify it works as expected.