### PR TITLE
Give the input field scroll bar more space

### DIFF
--- a/less/overrides.less
+++ b/less/overrides.less
@@ -16,7 +16,7 @@
 
     .mq-editable-field {
         .mq-root-block {
-            overflow-x: scroll !important;
+            overflow-x: scroll;
         }
 
         .mq-cursor:not(:only-child),

--- a/src/components/input/math-input.js
+++ b/src/components/input/math-input.js
@@ -99,8 +99,12 @@ class MathInput extends React.Component {
         this.mathField.setContent(this.props.value);
 
         this._container = ReactDOM.findDOMNode(this);
-
         this._root = this._container.querySelector('.mq-root-block');
+
+        const padding = this.getInputInnerPadding();
+        // NOTE(diedra): This overrides the default 2px padding from Mathquil.
+        this._root.style.padding = `${padding.paddingTop}px ${padding.paddingRight}px` +
+            ` ${padding.paddingBottom}px ${padding.paddingLeft}px`;
         this._root.style.fontSize = `${fontSizePt}pt`;
         this._root.addEventListener("scroll", () => this._hideCursorHandle());
 
@@ -787,9 +791,7 @@ class MathInput extends React.Component {
     // that MathQuill automatically applies 2px of padding to the inner
     // input.
     getInputInnerPadding = () => {
-        const builtInMathQuillPadding = 2;
-        const paddingInset = totalDesiredPadding - this.getBorderWidthPx() -
-            builtInMathQuillPadding;
+        const paddingInset = totalDesiredPadding - this.getBorderWidthPx();
 
         // Now, translate that to the appropriate padding for each direction.
         // The complication here is that we want numerals to be centered within
@@ -816,7 +818,6 @@ class MathInput extends React.Component {
         const innerStyle = {
             ...inlineStyles.innerContainer,
             borderWidth: this.getBorderWidthPx(),
-            ...this.getInputInnerPadding(),
             ...(focused ? {
                 borderColor: wonderBlocksBlue,
             } : {}),

--- a/src/components/input/math-input.js
+++ b/src/components/input/math-input.js
@@ -98,14 +98,10 @@ class MathInput extends React.Component {
 
         this.mathField.setContent(this.props.value);
 
+        this._updateInputPadding();
+
         this._container = ReactDOM.findDOMNode(this);
         this._root = this._container.querySelector('.mq-root-block');
-
-        const padding = this.getInputInnerPadding();
-        // NOTE(diedra): This overrides the default 2px padding from Mathquil.
-        this._root.style.padding = `${padding.paddingTop}px ${padding.paddingRight}px` +
-            ` ${padding.paddingBottom}px ${padding.paddingLeft}px`;
-        this._root.style.fontSize = `${fontSizePt}pt`;
         this._root.addEventListener("scroll", () => this._hideCursorHandle());
 
         // Record the initial scroll displacement on touch start. This allows
@@ -201,9 +197,13 @@ class MathInput extends React.Component {
         }
     }
 
-    componentDidUpdate() {
+    componentDidUpdate(prevProps, prevState) {
         if (this.mathField.getContent() !== this.props.value) {
             this.mathField.setContent(this.props.value);
+        }
+
+        if (prevState.focused !== this.state.focused) {
+            this._updateInputPadding()
         }
     }
 
@@ -225,6 +225,17 @@ class MathInput extends React.Component {
 
     _cacheKeypadBounds = (keypadNode) => {
         this._keypadBounds = keypadNode.getBoundingClientRect();
+    };
+
+    _updateInputPadding = () => {
+        this._container = ReactDOM.findDOMNode(this);
+        this._root = this._container.querySelector('.mq-root-block');
+
+        const padding = this.getInputInnerPadding();
+        // NOTE(diedra): This overrides the default 2px padding from Mathquil.
+        this._root.style.padding = `${padding.paddingTop}px ${padding.paddingRight}px` +
+            ` ${padding.paddingBottom}px ${padding.paddingLeft}px`;
+        this._root.style.fontSize = `${fontSizePt}pt`;
     };
 
     /*

--- a/src/components/input/math-input.js
+++ b/src/components/input/math-input.js
@@ -241,7 +241,7 @@ class MathInput extends React.Component {
         if (!this.state.focused) {
           return;
         }
-    
+
         /*
         If the next target is null (blurring to the body)
         Then prevent that from happening and refocus on the input
@@ -249,7 +249,7 @@ class MathInput extends React.Component {
         if (event.relatedTarget === null) {
           event.preventDefault();
           this.inputRef.focus();
-        } 
+        }
         /*
         Otherwise if the next element is something that's intentionally being
         select, either via tab or clicking then blur this input and dismiss
@@ -507,6 +507,8 @@ class MathInput extends React.Component {
             return;
         }
 
+        // NOTE(diedra): The adding and subtracting of 10 or 15 pixels here accounts
+        // for the padding that surrounds the input values.
         if (y > this._containerBounds.bottom) {
             y = this._containerBounds.bottom - 10;
         } else if (y < this._containerBounds.top) {
@@ -835,7 +837,7 @@ class MathInput extends React.Component {
         >
             {/* NOTE(charlie): This is used purely to namespace the styles in
                 overrides.css. */}
-            <div 
+            <div
                 className="keypad-input"
                 tabIndex={"0"}
                 ref={node => {


### PR DESCRIPTION
# SUMMARY
Issue: https://khanacademy.atlassian.net/browse/LP-7673
Design: https://www.figma.com/file/2lUPOSbOP8tbW7RLqbBFLh/Expression-Widget?node-id=542%3A1369

In PR #48 I added scrolling functionality to the expression widget input box. There are a couple of niggling things that bug me about it, and one of those things is that the scroll bar is super small, hard to see, and hard to grab onto. The issue is that the scrollable element is not very tall; all the padding in the input field belongs to its parent.

This diff moves the padding down one level to the scrollable element. That gives the scroll bar the space it needs while also not interfering with the logic around how much padding to put above and below the text.

There are a couple more improvements that I'm still planning to do:
- scroll the input field to the right when new values are added after the max width of the input field has been reached (I need to make a Jira for this)
- scroll the input field if the values have exceeded its max width and the user pulls the cursor handle off to the side where values are being hidden (Jira: https://khanacademy.atlassian.net/browse/LP-7695 )

# GIF
![scrollbar](https://user-images.githubusercontent.com/7761701/74072329-4bf0b680-49bb-11ea-8804-8f197ef431c3.gif)

# TEST PLAN
Navigate to /khan/math-input/index.html with mobile simulation on,
enter a few "normal" values (numbers and simple operators),
verify that the text is vertically centered,
add some more complicated values (like fractions and square roots),
verify that the text is still vertically centered,
enter in a whole bunch of values so you exceed the max width of the input field,
and verify the input box is horizontally scrollable.
Click/tap into the input field,
verify the cursor handle appears and looks good,
grab the handle,
pull it and let go in every direction you can think of,
and verify the handle + blinky cursor snap back to the input field at the location you would expect based on where you let go.