### PR TITLE
Add hover and active state styling [WIP]

### DIFF
--- a/less/overrides.less
+++ b/less/overrides.less
@@ -15,8 +15,25 @@
     outline: none !important;
 
     .mq-editable-field {
+        :active {
+            border: 2px solid #1B50B3 !important;
+        }
+
         .mq-root-block {
             overflow-x: scroll;
+            border: 2px solid rgba(0, 0, 0, 0);
+            min-height: inherit;
+        }
+
+        .mq-root-block:active {
+            /* White + 32% Blue */
+            background: linear-gradient(
+                0deg,
+                rgba(24, 101, 242, 0.32),
+                rgba(24, 101, 242, 0.32)
+            ), #FFFFFF;
+            border: 2px solid #1B50B3;
+            border-radius: 4px;
         }
 
         .mq-cursor:not(:only-child),

--- a/less/overrides.less
+++ b/less/overrides.less
@@ -11,14 +11,15 @@
 // change this animation length at all, we'd need to modify MathQuill as well.
 @cursorAnimationDuration: 500ms;
 
+// HACK(diedra): This overrides the border styling set in math-input.js
+.keypad-input > .mq-editable-field:active {
+    border: 2px solid #1B50B3 !important;
+}
+
 .keypad-input {
     outline: none !important;
 
     .mq-editable-field {
-        :active {
-            border: 2px solid #1B50B3 !important;
-        }
-
         .mq-root-block {
             overflow-x: scroll;
             border: 2px solid rgba(0, 0, 0, 0);


### PR DESCRIPTION
Jira: https://khanacademy.atlassian.net/browse/LP-7737
Design: https://www.figma.com/file/2lUPOSbOP8tbW7RLqbBFLh/Expression-Widget?node-id=542%3A1369

This is a WIP that I'm not going to finish right now because I can't test the hover work yet. But I'm putting it out in a PR for posterity so it's easier to pick up later. The big thing that still needs done is changing the implementation so the borders added on active and hover are outside the outer border, not outside the input field.

There is also currently a bug where the input field seems to expand by 1px when switching from default to another state.

Gif of active state:
![active](https://user-images.githubusercontent.com/7761701/74557339-c9b14680-4f14-11ea-9d48-e0c6759c9445.gif)
