### PR TITLE
Show overflow input values when typing or pulling cursor handle

### DIFF
--- a/src/components/input/math-input.js
+++ b/src/components/input/math-input.js
@@ -32,17 +32,12 @@ class MathInput extends React.Component {
         onBlur: PropTypes.func,
         onChange: PropTypes.func.isRequired,
         onFocus: PropTypes.func,
-        // Whether the input should be scrollable. This is typically only
-        // necessary when a fixed width has been provided through the `style`
-        // prop.
-        scrollable: PropTypes.bool,
         // An extra, vanilla style object, to be applied to the math input.
         style: PropTypes.any,
         value: PropTypes.string,
     };
 
     static defaultProps = {
-        scrollable: false,
         style: {},
         value: "",
     };
@@ -91,22 +86,13 @@ class MathInput extends React.Component {
             "mousedown.mathquill",
         );
 
-        // NOTE(charlie): MathQuill uses this method to do some layout in the
-        // case that an input overflows its bounds and must become scrollable.
-        // As it causes layout jank due to jQuery animations of scroll
-        // properties, we disable it unless it is explicitly requested (as it
-        // should be in the case of a fixed-width input).
-        if (!this.props.scrollable) {
-            this.mathField.mathField.__controller.scrollHoriz = function() {};
-        }
-
         this.mathField.setContent(this.props.value);
 
         this._updateInputPadding();
 
         this._container = ReactDOM.findDOMNode(this);
         this._root = this._container.querySelector(".mq-root-block");
-        this._root.addEventListener("scroll", () => this._hideCursorHandle());
+        this._root.addEventListener("scroll", this._handleScroll);
 
         // Record the initial scroll displacement on touch start. This allows
         // us to detect whether a touch event was a scroll and only blur the
@@ -342,6 +328,17 @@ class MathInput extends React.Component {
                 y: 0,
             },
         });
+    };
+
+    _handleScroll = () => {
+        // If animateIntoPosition is false, the user is currently manually positioning
+        // the cursor. This is important because the user can scroll the input field
+        // with the curor handle, and we don't want to override that ability.
+        // But we do want to hide the handle is the user is just scrolling the input field
+        // normally, because the handle will not move with the scroll.
+        if (this.state.handle.animateIntoPosition !== false) {
+            this._hideCursorHandle();
+        }
     };
 
     blur = () => {


### PR DESCRIPTION
# SUMMARY
Issue: https://khanacademy.atlassian.net/browse/LP-7812

It turns out that if we remove the code that overrides Mathquil's native scrolling logic, the extra scrolly behavior we want (scrolling on cursor handle pull and when the user is typing past the edge of the box) just magically work. For some reason, we still needed to add the `overflow: "scroll"` styles in `override.less` to get manually scrolling to work, but Mathquil can handle the other stuff for us.

So this diff mostly just removes the code that overrides Mathquil's code. That also means removing the `scrollable` prop, which I really should have removed before anyway, since we're now making the input field always scrollable. (Should we be concerned about removing this prop since this is an open source project? I actually don't have any experience with open source, so I really don't know.)

I also updated my code for hiding the cursor handle on scroll since that currently messes up the feature of scrolling by pulling on the cursor handle (for obvious reasons). This isn't actually part of the ticket I set out to do, but since Mathquil is giving it to us for free, why not? It's not perfect though. It works pretty well when scrolling the input field left by pulling on the cursor, but scrolling it right is really janky. So I was thinking of taking the ticket I had for implementing the scroll-on-handle-pull feature and, instead of closing it, updating it to instead say to make this feature better. But since it's already a P3, I don't know if we'll ever get to it, so maybe it's better to just close it? https://khanacademy.atlassian.net/browse/LP-7695

Giff of teh scrollz:
![scroll](https://user-images.githubusercontent.com/7761701/74991806-e5788900-53fb-11ea-8b72-a5cf5bb1f50b.gif)

# TEST PLAN
Open the expression widget,
type in a whole buncha values,
when you pass the max width of the input field, verify the input field scrolls to show the new values you insert,
verify you can manually scroll left and right by using a track pad, scroll wheel, or by pulling the scroll bar,
tap into the input field,
verify the cursor handle appears,
scroll the field again,
verify the handle disappears,
tap into the field again,
grab the cursor handle,
verify you can pull it around the input field,
pull it off the side of the input field in a direction that has hidden values,
and verify the input field scrolls to show the hidden values.