### PR TITLE
Fix prettier formatting in VSCode 

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,9 @@
+{
+    // See http://go.microsoft.com/fwlink/?LinkId=827846
+    // for the documentation about the extensions.json format
+    "recommendations": [
+        // Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+
+        "esbenp.prettier-vscode",
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,18 @@
+{
+    "editor.renderWhitespace": "boundary",
+    "eslint.autoFixOnSave": true,
+    "eslint.enable": true,
+    "files.trimTrailingWhitespace": true,
+    "flow.useNPMPackagedFlow": true,
+    "javascript.validate.enable": false,
+    "coverage-gutters.lcovname": "./coverage/lcov.info",
+    "jest.enableSnapshotUpdateMessages": false,
+    "jest.pathToConfig": "./config/jest/test.config.js",
+    "editor.codeActionsOnSave": {
+        "source.fixAll.eslint": true
+    },
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "[javascript]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+    }
+}


### PR DESCRIPTION
Fixes prettier formatting in VSCode by forcing code to not use its built in formatting.