### PR TITLE
Make input field aria label more specific

### DIFF
--- a/src/components/input/math-input.js
+++ b/src/components/input/math-input.js
@@ -817,6 +817,15 @@ class MathInput extends React.Component {
             ...style,
         };
 
+        // NOTE(diedra): This label explicitly refers to tapping because this field
+        // is currently only seen if the user is using a mobile device.
+        // We added the tapping instructions because there is currently a bug where
+        // Android users need to use two fingers to tap the input field to make the
+        // keyboard appear. It should only require one finger, which is how iOS works.
+        // TODO(diedra): Fix the bug that is causing Android to require a two finger tap
+        // to the open the keyboard, and then remove the second half of this label.
+        const ariaLabel = `{i18n._("Math input box") i18n._("Tap with one or two fingers to open keyboard")}`;
+
         return (
             <View
                 style={styles.input}
@@ -825,7 +834,7 @@ class MathInput extends React.Component {
                 onTouchEnd={this.handleTouchEnd}
                 onClick={(e) => e.stopPropagation()}
                 role={"textbox"}
-                ariaLabel={i18n._("Math input box")}
+                ariaLabel={ariaLabel}
             >
                 {/* NOTE(charlie): This is used purely to namespace the styles in
                 overrides.css. */}

--- a/src/components/keypad/index.js
+++ b/src/components/keypad/index.js
@@ -6,7 +6,7 @@ import {View} from "@khanacademy/wonder-blocks-core";
 import Color from "@khanacademy/wonder-blocks-color";
 import Clickable from "@khanacademy/wonder-blocks-clickable";
 
-import {Tabbar} from "../tabbar/tabbar";
+import Tabbar from "../tabbar/tabbar";
 import NumericInputPage from "./numeric-input-page";
 import PreAlgebraPage from "./pre-algebra-page";
 import TrigonometryPage from "./trigonometry-page";

--- a/stories/tabbar.stories.js
+++ b/stories/tabbar.stories.js
@@ -3,7 +3,7 @@ import {action} from "@storybook/addon-actions";
 import {withKnobs, select, array} from "@storybook/addon-knobs";
 
 import {TabbarItem} from "../src/components/tabbar/item";
-import {Tabbar} from "../src/components/tabbar/tabbar";
+import Tabbar from "../src/components/tabbar/tabbar";
 
 export default {title: "Tab Bar", decorators: [withKnobs]};
 

--- a/test/test_tabbar_component_spec.js
+++ b/test/test_tabbar_component_spec.js
@@ -2,7 +2,7 @@ import React from "react";
 import assert from "assert";
 import {mount} from "enzyme";
 
-import {Tabbar} from "../src/components/tabbar/tabbar";
+import Tabbar from "../src/components/tabbar/tabbar";
 
 describe("<Tabbar />", () => {
     it("defaults to selecting the first item", () => {


### PR DESCRIPTION
We have an issue where on Android mobile devices, you need to use two fingers to tap on the input field to make the keyboard appear. It should only require one finger to tap, which it does on iOS. We don't have time right now to figure out why this isn't working, so, for the meantime, we want to update the aria label to communicate that if one finger tapping isn't working, try two fingers.

There is another issue, not addressed here, where the aria label doesn't seem to work when you tap on the input field. It only activates if you navigate to the input field via swipes. So sighted users who are on an android device and using talkback won't hear this instruction. I don't know when we're going to deal with that. I might have to do that before closing the associated ticket.

![Screen Shot 2020-05-19 at 12 31 41 PM](https://user-images.githubusercontent.com/7761701/82370488-7fd17400-99cd-11ea-9895-fd7869947b8b.png)
